### PR TITLE
[2021.07.21] 전진성 BOJ 1018, 19699

### DIFF
--- a/notCoderJ/brute_force/1018.py
+++ b/notCoderJ/brute_force/1018.py
@@ -1,0 +1,39 @@
+'''
+    풀이 요약:
+        체스판의 대각선을 기준으로 짝수는 짝수끼리 홀수는 홀수끼리 같으면서
+        서로 반대의 색을 지닌다는 것을 이용해야겠다고 생각했습니다.
+        
+        짝수 대각선 : x, y인덱스의 합이 짝수 / 홀수 대각선 : x, y인덱스의 합이 홀수
+        1. 주어진 2차원 보드의 인덱스를 하나씩 탐색하며
+            해당 인덱스에서 8*8 크기 범위 내에서 짝수와 홀수 대각선의 각 White, Black수를 계산합니다.
+        2. 1번에서 계산한 짝수, 홀수 대각선에서의 각 White, Black 수에서 둘 중 작은 White와 Black의 수를 선택해 더해줍니다.
+        3. 주어진 보드의 범위 내에서 1, 2번 과정을 모두 수행한 후 가장 작은 값을 출력합니다.
+'''
+
+import sys
+
+input = lambda: sys.stdin.readline().rstrip()
+
+
+answer = float("inf")
+n, m = map(int, input().split())
+board = [input() for _ in range(n)]
+
+def paintCnt(i, j):
+    odd = [0, 0] # (W, B)
+    even = [0, 0]
+    
+    for x in range(i, i + 8):
+        for y in range(j, j + 8):
+            if (x + y) & 1:
+                odd[1 if board[x][y] == 'B' else 0] += 1
+            else:
+                even[1 if board[x][y] == 'B' else 0] += 1
+
+    return sum(map(min, zip(odd, even)))
+
+for i in range(n - 7):
+    for j in range(m - 7):
+        answer = min(answer, paintCnt(i, j))
+        
+print(answer)

--- a/notCoderJ/brute_force/19699.py
+++ b/notCoderJ/brute_force/19699.py
@@ -1,0 +1,62 @@
+from itertools import combinations
+from math import sqrt, floor
+import sys
+
+input = lambda: sys.stdin.readline().rstrip()
+
+
+n, m = map(int, input().split())
+cows = list(map(int, input().split()))
+
+'''
+    방법 1. 조합을 이용한 풀이
+    풀이 과정:
+        n과 m의 범위가 9이하이므로 완전 탐색을 통해 문제를 해결할 수 있다고 생각했습니다.
+        
+        1. 주어진 n마리의 소 중 m마리를 선택하는 모든 경우의 수를 구합니다.
+        2. 1번의 각 케이스마다 소들의 무게 합을 구하고 소수인지 판별합니다.
+            2-1. 소수를 판별하는 함수를 재귀함수로 구현했습니다.(어떤 수의 약수는 제곱근을 기준으로 대칭되므로 이를 이용했습니다.)
+        3. 2번에서 구한 소수가 없는 경우 -1, 있는 경우 오름차순으로 출력합니다.
+        
+        여기서, answer를 집합으로 구현한 것은 중복되는 무게가 있을 수 있기 때문입니다.
+'''
+chkPrime = lambda x, y: x if y < 2 else None if not x % y else chkPrime(x, y - 1)
+isPrime = lambda x: chkPrime(x, floor(sqrt(x))) 
+answer = sorted({isPrime(sum(pack)) for pack in combinations(cows, m)} - {None})
+print(*answer) if answer else print(-1)
+
+
+'''
+    방법 2: 재귀함수를 이용한 풀이
+    풀이 과정:
+        너무 조합으로만 푸는 느낌이 들어
+        희지님이 사용하셨던 '선택 vs 미선택' 방식을 채용해서 재귀로 구현해봤습니다.
+        다음에는 정규님이 사용하시던 '재귀 + for'도 도전해보겠습니다.
+        
+        1. 선택해야할 소의 수, 현재 선택 가능한 소의 수, 현재 무게의 합을 입력받는 재귀 함수를 수행합니다.
+        2. 현재 해당하는 번째의 소를 선택하는 경우와 선택하지 않는 경우에 대해 다음과 같이 값을 갱신하여 1번을 반복 수행합니다.
+            선택한 경우 : 선택해야할 소의 수 - 1, 현재 선택 가능한 소의 수 - 1, 현재 무게 + 현재 선택한 소의 무게
+            선택하지 않은 경우 : 선택해야할 소의 수, 현재 선택 가능한 소의 수 - 1, 현재 무게
+        3. 선택해야할 소의 수가 0인 경우 소수인지 검사해서 answer에 넣어주고 현재 선택 가능한 소의 수가 없는 경우 return을 수행합니다.
+        4. answer에 수가 존재하면 해당 수들을 오름차순으로 출력하고 없으면 -1을 출력합니다.
+    
+'''
+# answer = set()
+# isPrime = lambda x, y: {x} if y < 2 else set() if not x % y else isPrime(x, y - 1)
+
+# def selectCows(select, remain, weight):
+#     global answer
+
+#     if not select:
+#         answer |= isPrime(weight, floor(sqrt(weight)))
+#         return
+#     elif not remain:
+#         return
+    
+#     selectCows(select - 1, remain - 1, weight + cows[remain - 1])
+#     selectCows(select, remain - 1, weight)    
+
+# selectCows(m, n, 0)
+
+# print(*sorted(answer)) if answer else print(-1)
+


### PR DESCRIPTION
### `19699: 소-난다!`
두 방법 모두 answer를 집합으로 구현해 중복되는 무게를 제거했습니다.

- `방법 1. 조합을 이용한 풀이`
n과 m의 범위가 9이하이고 각 무게가 최대 1000이므로 소수를 구하는데 약 90회 연산 * nCm의 시간 복잡도이므로
완전 탐색을 통해 문제를 해결할 수 있다고 생각했습니다.

 1. 주어진 n마리의 소 중 m마리를 선택하는 모든 경우의 수를 구합니다.
 2. 1번의 각 케이스마다 소들의 무게 합을 구하고 소수인지 판별합니다.
   2-1. 소수를 판별하는 함수를 재귀함수로 구현했습니다.(어떤 수의 약수는 제곱근을 기준으로 대칭되므로 이를 이용했습니다.)
 3. 2번에서 구한 소수가 없는 경우 -1, 있는 경우 오름차순으로 출력합니다.

- `방법 2: 재귀함수를 이용한 풀이`
너무 조합으로만 푸는 느낌이 들어 희지님이 사용하셨던 '선택 vs 미선택' 방식을 채용해서 재귀로 구현해봤습니다.
다음에는 정규님이 사용하시던 '재귀 + for'도 도전해보겠습니다.
 1. 선택해야할 소의 수, 현재 선택 가능한 소의 수, 현재 무게의 합을 입력받는 재귀 함수를 수행합니다.
 2. 현재 해당하는 번째의 소를 선택하는 경우와 선택하지 않는 경우에 대해 다음과 같이 값을 갱신하여 1번을 반복 수행합니다.
   - 선택한 경우 : 선택해야할 소의 수 - 1, 현재 선택 가능한 소의 수 - 1, 현재 무게 + 현재 선택한 소의 무게
   - 선택하지 않은 경우 : 선택해야할 소의 수, 현재 선택 가능한 소의 수 - 1, 현재 무게
 3. 선택해야할 소의 수가 0인 경우 소수인지 검사해서 answer에 넣어주고 현재 선택 가능한 소의 수가 없는 경우 return을 수행합니다.
 4. answer에 수가 존재하면 해당 수들을 오름차순으로 출력하고 없으면 -1을 출력합니다.


### `1018: 체스판 다시 칠하기`
체스판의 대각선을 기준으로 짝수는 짝수끼리 홀수는 홀수끼리 같으면서 서로 반대의 색을 지닌다는 것을 이용해야겠다고 생각했습니다.

* 짝수 대각선 : x, y인덱스의 합이 짝수 / 홀수 대각선 : x, y인덱스의 합이 홀수

1. 주어진 2차원 보드의 인덱스를 하나씩 탐색하며 해당 인덱스에서 8*8 크기 범위 내에서 짝수와 홀수 대각선의 각 White, Black수를 계산합니다.
2. 1번에서 계산한 짝수, 홀수 대각선에서의 각 White, Black 수에서 둘 중 작은 White와 Black의 수를 선택해 더해줍니다.
3. 주어진 보드의 범위 내에서 1, 2번 과정을 모두 수행한 후 가장 작은 값을 출력합니다.
