### PR TITLE
[2021.07.21] 이정규 BOJ 1018, 19699

### DIFF
--- a/JeongGod/1018.py
+++ b/JeongGod/1018.py
@@ -1,0 +1,47 @@
+'''
+m*n board
+색칠하는 경우
+1. 맨 왼쪽 위칸이 흰색인 경우
+2. 맨 왼쪽 위칸이 검은색인 경우
+
+1인경우
+    - board[0][0] = 1이라면
+    board[짝수][홀수] = 0과 다르다면 개수를 늘린다.
+    board[홀수][짝수] = 0과 다르다면 개수를 늘린다.
+2인 경우는 1로 무조건 바꾼다는 것만 빼면 같다.
+
+'''
+import sys, math
+input = sys.stdin.readline
+
+n,m = map(int, input().split())
+
+board = [list(input().rstrip()) for _ in range(n)]
+
+ans = math.inf
+
+
+for row in range(n-7):
+    for col in range(m-7):
+        for num in range(2):
+            if num == 0:
+                target = "BW"
+            else:
+                target = "WB"
+            result = 0
+            for i in range(row, row+8):
+                for j in range(col, col+8):
+                    # 행의 짝홀 판단
+                    if i%2 == 0: 
+                    # 열의 짝홀 판단
+                        if j%2 == 1 and board[i][j] != target[0]:
+                            result += 1
+                        elif j%2 == 0 and board[i][j] != target[1]:
+                            result += 1
+                    elif i%2 == 1:
+                        if j%2 == 1 and board[i][j] != target[1]:
+                            result += 1
+                        elif j%2 == 0 and board[i][j] != target[0]:
+                            result += 1
+            ans = min(result, ans)
+print(ans)

--- a/JeongGod/19699.py
+++ b/JeongGod/19699.py
@@ -1,0 +1,30 @@
+'''
+m개를 뽑았을때의 합이 소수가 되도록 하여라
+해당 소수들을 리스트에 담는다.
+소수는 오름차순으로 출력한다.
+'''
+import sys
+from itertools import combinations
+input = sys.stdin.readline
+
+n, m = map(int, input().split())
+
+cow = list(map(int, input().split()))
+
+# 아리토스테네스의 채 이용
+prime = [True for i in range(9001)]
+for i in range(2,9001):
+    for j in range(2*i, 9001, i):
+        if prime[j]:
+            prime[j] = False
+
+_set = set()
+for elems in combinations(cow, m):
+    result = 0
+    for elem in elems:
+        result += elem
+    if prime[result]:
+        _set.add(result)
+
+
+print(" ".join(map(str, sorted(_set))) if len(_set) > 0 else -1)


### PR DESCRIPTION
### 1018 - 체스판 다시 칠하기
1. 8*8의 체스판을 모두 돌아보면서 확인하는 것으로 했습니다.
2. 최대 50*50의 체스판을 8*8의 체스판으로 둘러보는걸로 하였습니다.
3. 8*8의 체스판을 둘러보는 기준은 board[0][0] = "W" or "B"로 그 기준을 정했습니다.
- 만약 board[0][0] = "W" 라면 
 board[짝수][홀수] = "B"
 board[짝수][짝수] = "W"
 board[홀수][짝수] = "B"
 board[홀수][홀수] = "W"
 로 만약 다르다면, 해당 체스판을 다시 칠해야 하는 것으로 하였습니다.
 board[0][0] = "B"는 위와 동일한 로직으로 진행됩니다.

4. 이게 곧 (50-8+1)(50-8+1)만큼 돈다. 그래서 총 시간복잡도는 O(2*(8*8) * 43 * 43)으로 충분히 돌 수 있다.
n이 작아서 숫자로 시간복잡도를 표현해봤습니다.

### 19699 - 소-난다!
1. 소수를 판단하는 기준으로는 "에라토스테네스의 체"를 이용했는데 알고리즘이 어렴풋이 기억나서 생각대로 적어봤더니 정확하지 않네요.. 
 정확한 코드는
```python
for i in range(2,9001):
    if prime[j]:
         for j in range(2*i, 9001, i):
               prime[j] = False
```
소수를 구하는 코드중에서는 가장 빠르다고 합니다. O(n log log n)이라고 하네요.

2. 조합의 합이 소수라면, 중복을 제거하기 위해 집합에다가 넣었습니다.
3. 그리고 집합을 정렬한 뒤 출력합니다.