### PR TITLE
[2021.07.26] 전진성 - BOJ 17129, 21938

### DIFF
--- a/notCoderJ/dfs_bfs/17129.py
+++ b/notCoderJ/dfs_bfs/17129.py
@@ -1,0 +1,50 @@
+'''
+    풀이 요약:
+        이동 경로 간 가중치가 1이고 최단 거리를 구하는 문제이므로 bfs를 이용하면 되겠다고 생각했습니다.
+        
+        1. 주어진 맵 정보를 입력받으며 값이 2인 경우 시작점에 해당하므로 deque의 시작 값으로 넣어줍니다.(이때 deque에는 현재 좌표 x, y와 해당 지점의 값, 현재 지점까지 거리 정보를 넣어줍니다.)
+        
+        2. deque이 비거나 최단 경로에 있는 음식점을 찾을 때까지 bfs를 반복 수행합니다.
+            - 현재 지점에서 상하좌우에 있는 지점 중 주어진 맵을 벗어나지 않고 빈 복도이거나 해당 지점 값이 2보다 큰 경우에 대해서 다음을 수행합니다.
+                deque에 해당 지점 좌표와 지점 값, 현재까지 거리 + 1을 추가하고
+                해당 지점 값을 1로 변경하여 지나갈 수 없는 지역으로 만들어 줍니다.(방문처리)
+'''
+
+from collections import deque
+import sys
+input = lambda: sys.stdin.readline().rstrip()
+
+
+answer = -1
+n, m = map(int, input().split())
+
+dq = deque([])
+island = []
+directions = [(-1, 0), (1, 0), (0, -1), (0, 1)] # 상하좌우
+
+for i in range(n):
+    island.append([])
+    for j, k in enumerate(map(int, input())):
+        if k == 2:
+            dq.append((i, j, k, 0))
+        island[-1].append(k)
+
+while dq:
+    x, y, i, d = dq.popleft()
+    
+    if i > 2:
+        answer = d
+        break
+    
+    for dx, dy in directions:
+        nx, ny = x + dx, y + dy
+        if nx >= 0 and nx < n and ny >= 0 and ny < m \
+            and (island[nx][ny] > 2 or island[nx][ny] == 0):
+                dq.append((nx, ny, island[nx][ny], d + 1))
+                island[nx][ny] = 1
+    
+if answer != -1:
+    print("TAK")
+    print(answer)
+else:
+    print("NIE")

--- a/notCoderJ/dfs_bfs/21938.py
+++ b/notCoderJ/dfs_bfs/21938.py
@@ -1,0 +1,68 @@
+'''
+    풀이 요약:
+        먼저 주어지는 각 픽셀의 RGB 정보를 입력받아 픽셀의 RGB 평균값을 구하고 리스트에 저장합니다.
+        1. dfs 풀이
+            n * m 픽셀을 하나씩 탐색하며 해당 픽셀의 평균값이 경계값(t)보다 크고 256(방문 처리)이 아닌 값이 존재할 경우 물체의 수를 1 증가시키고 해당 픽셀에서 dfs를 수행합니다.
+            
+            dfs는 해당 픽셀의 값을 256으로 변경하여 방문 처리한 후 n*m 화면을 벗어나지 않고
+            값이 t보다 크거나 같은 방문하지 않은 상하좌우에 있는 픽셀에 대해 dfs를 반복적으로 수행하여 물체를 표시합니다.
+            
+        2. bfs 풀이
+            dfs와 동일한 로직이며 dfs를 수행하는 부분을 bfs로 대체하여 수행합니다.
+'''
+
+
+from collections import deque
+import sys
+input = lambda: sys.stdin.readline().rstrip()
+
+
+answer = 0
+n, m = map(int, input().split())
+avg = lambda x: sum(x) / 3
+
+screen = [[] for _ in range(n)]
+for i in range(n):
+    line = tuple(map(int, input().split()))
+    for j in range(0, 3 * m, 3):
+        screen[i].append(avg(line[j:j+3]))
+t = int(input())
+
+directions = [(-1, 0), (1, 0), (0, -1), (0, 1)] # 상하좌우
+
+# bfs 풀이
+def processImg(i, j):
+    dq = deque([(i, j)])
+    
+    while dq:
+        x, y = dq.popleft()
+        for dx, dy in directions:
+            nx, ny = x + dx, y + dy
+            if nx >= 0 and nx < n and ny >= 0 and ny < m \
+                and screen[nx][ny] >= t and screen[nx][ny] < 256:
+                screen[nx][ny] = 256
+                dq.append((nx, ny))
+
+
+for i in range(n):
+    for j in range(m):
+        if screen[i][j] >= t and screen[i][j] < 256:
+            answer += 1
+            processImg(i, j)
+
+print(answer)
+
+
+# dfs 풀이
+# def processImg(x, y):
+#     if screen[x][y] < t or screen[x][y] == 256:
+#         return False
+    
+#     screen[x][y] = 256
+    
+#     for dx, dy in directions:
+#         nx, ny = x + dx, y + dy
+#         if nx >= 0 and nx < n and ny >= 0 and ny < m:
+#             processImg(nx, ny)
+
+#     return True


### PR DESCRIPTION
`###  17129: 윌리암슨수액빨이딱따구리가 정보섬에 올라온 이유`
이동 경로 간 가중치가 1이고 최단 거리를 구하는 문제이므로 bfs를 이용하면 되겠다고 생각했습니다.

1. 주어진 맵 정보를 입력받으며 값이 2인 경우 시작점에 해당하므로 deque의 시작 값으로 넣어줍니다.(이때 deque에는 현재 좌표 x, y와 해당 지점의 값, 현재 지점까지 거리 정보를 넣어줍니다.)
        
2. deque이 비거나 최단 경로에 있는 음식점을 찾을 때까지 bfs를 반복 수행합니다.
  2-1. 현재 지점에서 상하좌우에 있는 지점 중 주어진 맵을 벗어나지 않고 빈 복도이거나 해당 지점 값이 2보다 큰 경우에 대해서 다음을 수행합니다.
 - deque에 해당 지점 좌표와 지점 값, 현재까지 거리 + 1을 추가하고 해당 지점 값을 1로 변경하여 지나갈 수 없는 지역으로 만들어 줍니다.(방문처리)

`###  21938: 영상처리`
bfs나 dfs 둘 다 가능하겠다고 생각하여 먼저 dfs를 시도하였습니다. 처음에는 주어진 맵을 모두 입력받고 방문처리용 테이블도 하나 만들어 시도하였지만 메모리 초과로 1차 실패.
그래서 방문처리용 테이블을 삭제하고 주어진 맵을 그대로 이용하는 방법으로 시도하였으나 메모리 초과로 2차 실패.
아예 처음부터 입력받으면서 평균을 구해서 저장해놓고 비교하였으나 메모리 초과로 또 실패. 반복적인 메모리 초과로 멘탈이 붕괴됬다가 파이썬으로 다시 제출해보니 성공...??
그래도 메모리 사용량이나 수행 속도를 보니 bfs가 낫겠다고 생각하여 다시 bfs로 풀었습니다.

 1. dfs 풀이
    n * m 픽셀을 하나씩 탐색하며 해당 픽셀의 평균값이 경계값(t)보다 크고 256(방문 처리)이 아닌 값이 존재할 경우 물체의 수를 1 증가시키고 해당 픽셀에서 dfs를 수행합니다.

- dfs는 해당 픽셀의 값을 256으로 변경하여 방문 처리한 후 n*m 화면을 벗어나지 않고 값이 t보다 크거나 같은 방문하지 않은 상하좌우에 있는 픽셀에 대해 dfs를 반복적으로 수행하여 물체를 표시합니다.

2. bfs 풀이 : dfs와 동일한 로직이며 dfs를 수행하는 부분을 bfs로 대체하여 수행합니다.

