### PR TITLE
[2021.07.27] 이정규 BOJ 7576, 18352

### DIFF
--- a/JeongGod/18352.py
+++ b/JeongGod/18352.py
@@ -1,0 +1,37 @@
+import sys
+from collections import deque
+input = sys.stdin.readline
+
+n, m, k, x = map(int, input().split())
+
+board = [[] for _ in range(n+1)] # 1 ~ N
+for _ in range(m):
+    ax, ay = map(int, input().split())
+    board[ax].append(ay)
+
+dq = deque()
+visited = [False for i in range(n+1)]
+
+# 출발도시중에서 연결되어있는 도시들을 덱에 넣고, 방문표시를 한다.
+visited[x] = True
+dq.append((x,0))
+
+ans = []
+# 덱이 빌때까지 반복한다.
+while dq:
+    n_node, val = dq.popleft()
+    if val == k:
+        ans.append(n_node)
+        continue
+
+    for node in board[n_node]:
+        if not visited[node]:
+            dq.append((node, val+1))
+            visited[node] = True
+
+ans = sorted(ans)
+if len(ans) == 0:
+    print(-1)
+else:
+    for i in ans:
+        print(i)

--- a/JeongGod/7576.py
+++ b/JeongGod/7576.py
@@ -1,0 +1,49 @@
+'''
+익은 것과 익지 않은 것이 존재한다.
+익지 않은 것 옆에 익은게 있다면 하루 뒤에 익는다.
+다 익을때의 최소 일수를 구하고 싶다.
+
+visited를 안 쓰는 대신, 익은 토마토를 기준으로 하나씩 늘려가면서 board에 저장.
+'''
+
+import sys
+from collections import deque
+input = sys.stdin.readline
+
+n, m = map(int, input().split())
+
+dq = deque()
+board = []
+
+for x in range(m):
+    tmp = list(map(int, input().split()))
+    board.append(tmp)
+    for y, val in enumerate(tmp):
+        if val == 1:
+            dq.append((x, y))
+
+idx = [(1,0), (-1,0), (0,1), (0,-1)]
+
+def check(x,y):
+    if 0 <= x < m and 0 <= y < n and board[x][y] == 0:
+        return True
+    return False
+
+ans = 0
+while dq:
+    x,y = dq.popleft()
+
+    for dir in idx:
+        nx = x+dir[0]
+        ny = y+dir[1]
+        if check(nx, ny):
+            board[nx][ny] += board[x][y]+1
+            ans = max(ans, board[nx][ny])
+            dq.append((nx, ny))
+
+for i in board:
+    if 0 in i:
+        print(-1)
+        exit()
+# 처음 입력이 다 익어있는 토마토라면 0을 내뱉어야 하지만, 1을 내뱉게 되서 처리했습니다.
+print(ans if ans == 0 else ans-1)


### PR DESCRIPTION
### `7576 : 토마토`
BFS로 풀었습니다.
visited대신에 board에 토마토까지 된 걸린 시간을 업데이트하여 방문했는지 안 했는지를 판단했습니다.

### `18352 : 특정 거리의 도시 찾기`
BFS로 풀었습니다. 
DFS형식으로 풀어볼라 했지만 안되더군요. 최단거리만을 기억하고 있어야 해서 문제였습니다. 그 뒤에 로직은 제가 생각을 못하겠어서 포기했네요.

처음에 메모리 초과로 힘들었는데 도시끼리의 연결을 n*n으로 표현하다보니, 90억개의 리스트로 메모리초과가 났습니다. 보통 1억개의 크기면 381MB라네요. 
또, k의 범위가 1부터 300,000으로 생각하고 풀었는데 자꾸 70%에서 틀렸다고 나와 힘들었네요. k=0인 테스트케이스도 있는 것 같습니다. 그래서 문의를 넣긴 했는데.. 제가 틀린 건지 한 번 봐주시면 감사하겠습니다!
line 15 ~ 17대신 이렇게 넣으면 틀립니다. 같은 로직이지 않나요..? 만약 k가 1이상이면 성립하는 로직같다고 생각합니다.
```python
# 출발도시중에서 연결되어있는 도시들을 덱에 넣고, 방문표시를 한다.
visited[x] = True
for node in board[x]:
    dq.append((node,1))
    visited[node] = True
```
마지막 출력할 때, join사용을 위해서 답을 string형으로 바꾸니 또 틀렸다고 해서 많이 헤맸네요.ㅠㅠ 정해진 형식을 맞춰야 하는 것 같습니다..
