### PR TITLE
[2021.07.29] 이정규 BOJ 2206, 7569

### DIFF
--- a/JeongGod/2206.py
+++ b/JeongGod/2206.py
@@ -1,0 +1,64 @@
+import sys, copy
+from collections import deque
+input = sys.stdin.readline
+
+n,m = map(int, input().split())
+board = [list(input().rstrip()) for i in range(n)]
+# 1,1이 들어온다면 바로 끝내게 설정했습니다.
+if n == 1 and m == 1:
+    print(1)
+    exit()
+
+wall_visited = copy.deepcopy(board)
+
+dq = deque([(0, 0, False, 1)])
+board[0][0], wall_visited[0][0] = -1, -1
+# 0,0 부터 시작한다.
+dir = [(0,-1), (0,1), (1,0), (-1,0)]
+
+def check(nx, ny, wall):
+    if 0 <= nx < m and 0 <= ny < n:
+        # 벽을 뚫은 경우에는 벽의 방문경로로 판단한다.
+        if wall:
+            if wall_visited[ny][nx] == '0':
+                return 2
+        # 벽이 아니라면
+        elif not wall:
+            # 갈 수 있는 공간
+            if board[ny][nx] == '0':
+                return 1
+            # 벽을 만났지만 부수지 않은 경우라면
+            elif board[ny][nx] == '1':
+                return 2
+    return 0
+
+result = 1e9
+while dq:
+    x, y, wall, ans = dq.popleft()
+
+    for idx in dir:
+        nx = x+idx[0]
+        ny = y+idx[1]
+        if nx == m-1 and ny == n-1:
+            ans += 1
+            result = min(result, ans)
+        way = check(nx, ny, wall)
+
+        if way > 0:
+            # 벽을 부수지 않은 경우
+            if not wall:
+                board[ny][nx] = '-1'
+                wall_visited[ny][nx] = '-1'
+            # 벽을 이미 부쉈던 경우
+            else:
+                wall_visited[ny][nx] = '-1'
+
+            # 벽이 아닐 경우에는
+            if way == 1:
+                dq.append((nx, ny, wall, ans+1))
+            # 벽을 부순 경우거나 이미 부쉈던 경우인데 가능하다면
+            elif way == 2:
+                dq.append((nx, ny, True, ans+1))
+
+print(result if result != 1e9 else -1)
+

--- a/JeongGod/2206.py
+++ b/JeongGod/2206.py
@@ -32,33 +32,32 @@ def check(nx, ny, wall):
                 return 2
     return 0
 
-result = 1e9
-while dq:
-    x, y, wall, ans = dq.popleft()
+def bfs():
+    while dq:
+        x, y, wall, ans = dq.popleft()
+        for idx in dir:
+            nx = x+idx[0]
+            ny = y+idx[1]
+            if nx == m-1 and ny == n-1:
+                ans += 1
+                return ans
+            way = check(nx, ny, wall)
 
-    for idx in dir:
-        nx = x+idx[0]
-        ny = y+idx[1]
-        if nx == m-1 and ny == n-1:
-            ans += 1
-            result = min(result, ans)
-        way = check(nx, ny, wall)
+            if way > 0:
+                # 벽을 부수지 않은 경우
+                if not wall:
+                    board[ny][nx] = '-1'
+                    wall_visited[ny][nx] = '-1'
+                # 벽을 이미 부쉈던 경우
+                else:
+                    wall_visited[ny][nx] = '-1'
 
-        if way > 0:
-            # 벽을 부수지 않은 경우
-            if not wall:
-                board[ny][nx] = '-1'
-                wall_visited[ny][nx] = '-1'
-            # 벽을 이미 부쉈던 경우
-            else:
-                wall_visited[ny][nx] = '-1'
-
-            # 벽이 아닐 경우에는
-            if way == 1:
-                dq.append((nx, ny, wall, ans+1))
-            # 벽을 부순 경우거나 이미 부쉈던 경우인데 가능하다면
-            elif way == 2:
-                dq.append((nx, ny, True, ans+1))
-
-print(result if result != 1e9 else -1)
+                # 벽이 아닐 경우에는
+                if way == 1:
+                    dq.append((nx, ny, wall, ans+1))
+                # 벽을 부순 경우거나 이미 부쉈던 경우인데 가능하다면
+                elif way == 2:
+                    dq.append((nx, ny, True, ans+1))
+result = bfs()
+print(result if result != None else -1)
 

--- a/JeongGod/7569.py
+++ b/JeongGod/7569.py
@@ -1,0 +1,49 @@
+import sys
+from collections import deque
+input = sys.stdin.readline
+
+N, M, H = map(int, input().split())
+# 3차원 배열을 만들고, 상하좌우 위아래를 보면서 돌아가자.
+
+board = [[] for i in range(H)]
+dq = deque()
+
+for h in range(H):
+    for y in range(M):
+        tmp = list(map(int, input().split()))
+        # 익은 토마토를 덱에 넣는다.
+        for x in range(len(tmp)):
+            if tmp[x] == 1:
+                dq.append((h, x, y))
+        
+        board[h].append(tmp)
+
+# h,x,y
+dir = [(0,0,1), (0,0,-1), (0,1,0), (0,-1,0), (1,0,0), (-1,0,0)]
+
+def check(nh, nx, ny):
+    # 보드밖으로 나갔는지 판단
+    if 0 <= nh < H and 0 <= nx < N and 0 <= ny < M and board[nh][ny][nx] == 0:
+        return True
+    return False
+
+h,x,y = 0,0,0
+while dq:
+    h, x, y = dq.popleft()
+
+    for idx in dir:
+        nh = h+idx[0]
+        nx = x+idx[1]
+        ny = y+idx[2]
+        if check(nh, nx, ny):
+            dq.append((nh, nx, ny))
+            board[nh][ny][nx] = board[h][y][x] + 1
+
+def zero_check():
+    for h in board:
+        for y in h:
+            if 0 in y:
+                return False
+    return True
+print(board[h][y][x]-1 if zero_check() else -1)
+


### PR DESCRIPTION
### `2206 - 벽 부수고 이동하기`
"벽을 부순 경우" 와 "벽을 부수지 않은 경우"의 경로를 나눠서 생각했습니다. 처음에는 합쳐서 생각하다 틀려서 질문게시판을 봤네요.

<line 50 ~ 51>
벽을 부수지 않은 경우에서 벽을 부순경우도 같이 업데이트 하는 이유는, 벽을 부순 경우에서의 경로 길이 == 벽을 부수지 않은 경로 길이이기 때문입니다.
결국, 벽을 부순 경우에서 다시 벽을 부수지 않은 경로를 가는 곳은 비효율적이라고 판단해서 짜봤는데 없나 있으나 시간은 50ms밖에 차이가 안나네요. 

<풀이>
1. 현재 위치에서 상하좌우가 가능한지 탐색합니다. 이전에 벽을 뚫었다면, wall_visited에서 가능한지 탐색합니다.
2. 벽을 부수지 않았다면, 일반 visited에 표시합니다. 벽을 "이전에" 부숴놨다면 wall_visited에 표시합니다. 
3. 만약 통과가능한 곳이라면, 벽을 뚫어서 통과했는지 판단하여 덱에 넣습니다.
4. 위를 반복하여 끝점에 다다르면 , 가장 최적의 값이므로 return합니다.

### `7569 - 토마토`
로직은 저번 토마토와 같습니다. 3차원이라고 해서 상하좌우 + (위층, 아래층)을 추가하여 진행했습니다.