### PR TITLE
[2021.07.29] 임희지 BOJ 7569, 2206

### DIFF
--- a/limhizy15/graph_traversal/2206.py
+++ b/limhizy15/graph_traversal/2206.py
@@ -1,0 +1,68 @@
+# 벽 부수고 이동하기
+"""
+n * m 맵이 있다. 0은 이동할 수 있는 곳, 1은 이동할 수 없는 곳.
+(1, 1) 부터 (N, M)까지 가려는데 최단 경로로 가려한다.
+이동 도중 벽을 한개 부술 수 있다.
+시작, 도착점은 항상 0이다.
+
+bfs탐색을 한다.
+덱에 삽입되는 것은 (y, x, cnt)로 위치와 벽을 부순 횟수를 나타낸다.
+visited는 3차원으로 [0]이면 안 부수고 지나간 것 [1]이면 부수고 지나간 것
+"""
+import sys
+from collections import deque
+
+input = sys.stdin.readline
+
+# n, m 입력 세로가로
+n, m = map(int, input().split())
+
+# 보드 입력
+board = [list(map(int, input().rstrip())) for _ in range(n)]
+
+# 방문 여부 판단 
+# [[[0, 1], [0, 1], [0, 1]],
+#  [[0, 1], [0, 1], [0, 1]]]
+# 벽을 안부수고 방문 & 벽을 부수고 방문 => 방문 체크 겸 거리 계산도
+visited = [[[0]*2 for _ in range(m)] for _ in range(n)]
+
+# bfs 탐색 세팅
+dq = deque()
+dq.append((0, 0, 0))  # 시작점과 벽부순 횟수 추가 (0)
+visited[0][0][0] = 1  # 안부수고 방문했으니까!
+# visited[0][0][1] = 1
+
+# 네 방향
+dy = [-1, 1, 0, 0]
+dx = [0, 0, -1, 1]
+
+
+# bfs 탐색
+while dq:
+    y, x, cnt = dq.popleft()
+    # print(y, x, cnt)
+    for i in range(4):
+        ny, nx = y + dy[i], x + dx[i]
+        # 범위를 벗어난 경우
+        if ny < 0 or ny >= n or nx < 0 or nx >= m: continue
+        # 빈칸이고 아직 방문하지 않은 곳이라면
+        if board[ny][nx] == 0 and visited[ny][nx][cnt] == 0:
+            visited[ny][nx][cnt] = visited[y][x][cnt] + 1
+            dq.append((ny, nx, cnt))
+        # 다음칸이 벽이고, 아직 벽을 부수지 않았고, 해당 벽을 부수고 방문한 적이 없으면
+        if cnt == 0 and board[ny][nx] == 1 and visited[ny][nx][cnt+1] == 0:
+            visited[ny][nx][cnt+1] = visited[y][x][cnt] + 1
+            dq.append((ny, nx, cnt+1))  # 벽을 부순 횟수를 갱신해줘야
+
+
+# bfs 호출
+# bfs()
+
+if visited[n-1][m-1][0] != 0 and visited[n-1][m-1][1] != 0:
+    print(min(visited[n-1][m-1][0], visited[n-1][m-1][1]))
+elif visited[n-1][m-1][0] != 0:
+    print(visited[n-1][m-1][0])
+elif visited[n-1][m-1][1] != 0:
+    print(visited[n-1][m-1][1])
+else:
+    print(-1)

--- a/limhizy15/graph_traversal/7569.py
+++ b/limhizy15/graph_traversal/7569.py
@@ -1,0 +1,76 @@
+# 토마토
+"""
+[문제]
+1. M * N * H 창고에 토마토가 있다. 
+2. 익지 않은 토마토는 익은 토마토의 영향을 받아 익는다. (위, 아래, 왼쪽, 오른쪽, 앞, 뒤)
+3. 며칠이 지나면 토마토가 다 익는지 구해라.
+
+[풀이]
+BFS 탐색할 때 네 방향 + 위, 아래 체크
+3차원 배열 입력은 어떻게 받을 것인가?
+"""
+import sys
+from collections import deque
+
+input = sys.stdin.readline
+
+# M: 가로, N: 세로, H: 상자의 수 입력
+m, n, h = map(int, input().split())
+
+# 가장 밑의 상자부터 위에까지 토마토 정보 입력
+board = [[list(map(int, input().split())) for _ in range(n)] for _ in range(h)]
+
+# 보드를 탐색하면서 1인 곳의 좌표를 덱에 저장
+dq = deque()
+for i in range(h):
+    for j in range(n):
+        for k in range(m):
+            if board[i][j][k] == 1:
+                dq.append((i, j, k))
+
+# 상 하 좌 우 위 아래
+dy = [-1, 1, 0, 0, 0, 0]
+dx = [0, 0, -1, 1, 0, 0]
+dz = [0, 0, 0, 0, -1, 1]
+
+# bfs
+def bfs():
+    # 덱이 빌 때까지
+    while dq:
+        # 가장 앞에 있는 요소를 꺼낸다.
+        cz, cy, cx = dq.popleft()
+        # 6방향을 탐색한다. 2차원기준 상하좌우와 3차원 기준 위아래
+        
+        for i in range(6):
+            nz, ny, nx = cz + dz[i], cy + dy[i], cx + dx[i]
+            # 범위 체크
+            if nz < 0 or nz >= h or ny < 0 or ny >= n or nx < 0 or nx >= m: continue
+            if board[nz][ny][nx] != 0: continue
+            # 보드 값을 +1로 갱신
+            board[nz][ny][nx] = board[cz][cy][cx] + 1
+            dq.append((nz, ny, nx))
+
+# bfs 탐색
+bfs()
+
+answer = 0
+flag = False
+
+# 보드를 모두 돌면서 익지 않은 곳이 있는지 체크
+for i in range(h):
+    for j in range(n):
+        for k in range(m):
+            if board[i][j][k] == 0:
+                answer = -1
+                flag = True
+                break
+            elif answer < board[i][j][k]:
+                answer = board[i][j][k]
+        if flag: break
+    if flag: break
+
+# 출력
+if flag:
+    print(answer)
+else:
+    print(answer - 1)


### PR DESCRIPTION
### `7569 - 토마토`
얼마전에 푼 토마토랑 로직은 똑같습니다. 
1. n * m * h 배열에 토마토 정보를 입력 받는다. (보드)
2. 보드를 탐색하면서 1인 곳의 좌표를 덱에 담는다.
3. BFS탐색
-> 덱 가장 앞의 요소를 꺼낸다.
-> 6방향을 탐색한다. (2차원 기준 상하좌우, 3차원 기준 위아래)
-> 다음 좌표가 보드의 영역을 벗어나거나 0이 아니어서 이미 익은 토마토이면 스킵
-> 아닌 경우 방문해서 토마토 값을 기준 토마토 + 1로 갱신해주고 덱에 좌표 삽입
4. 탐색이 끝나고 보드를 돌면서 아직 익지 않은 곳이 있는지 체크 & 가장 큰 값을 찾아서 필요한 일수를 구함

- 3차원 입력은 감이 안와서 구글링해서 찾았습니다!
```python
board = [[list(map(int, input().split())) for _ in range(n)] for _ in range(h)]
```
---
### `2206 - 벽 부수고 이동하기`
처음에는 그냥 벽을 하나도 부수지 않은 상태에서 bfs탐색하고, 보드를 탐색하면서 벽을 지우고 bfs탐색하는 방법을 생각했는데 n, m이 최대 1000이라 안돌아갈 것 같았습니다. (정확한 시간복잡도는 모르겠네요 ㅎㅎ)
그러다가 그럼 벽을 부순 경우와 부수지 않은 경우를 나눠야겠다고 생각했고 방문을 체크하는 visited 배열을 두개 만들었는데, 이렇게 하니까 헷갈리더라구요.. 그래서 visited[i][j][0] 이런식으로 방문배열을 만들었습니다.

설계 하는게 어려웠어요.. 그래서 중간중간 검색을 좀 했습니다 ㅎㅎ
`빈칸 to 빈칸`은 항상 가능
`빈칸 to 벽`은 아직 한 번도 벽을 부순 적이 없으면 이동 가능
`벽 to 빈칸`은 항상 가능 (왜냐하면 벽에서 빈칸으로 이동한다는 뜻은 부순벽에서 이동하는 거니까!)
`벽 to 벽`은 불가능 (벽을 한 번만 부술 수 있으므로)
-> 전체적으로 이런 경우의 수를 생각하면서 코드를 짰습니다.

1. 방문여부를 확인할 visited 배열을 생성한다. 좌표가 (i, j, k)라고 하면 k가 0이면 부수지 않고 방문한 경우, k가 1이면 부수고 방문한 경우를 나타낸다.
2. 덱을 만들고 시작점과 벽을 부순 횟수를 삽입한다. (0, 0, 0)
3. 제일 앞에 걸 꺼내서 y, x, cnt에 넣는다. y, x는 좌표, cnt는 벽을 부순 횟수
4. 네 방향을 탐색해서 다음 좌표를 구한다.
-> 범위 벗어나는 경우 스킵
-> 다음 좌표가 빈칸이고(벽이 아니고) 아직 방문하지 않은 곳이라면:
    이전 좌표의 값 + 1로 갱신해주고 덱에 넣는다. => 일반 bfs랑 똑같음
-> 다음 좌표가 벽이고, 현재 cnt가 0으로 벽을 부순 적이 없다. & **다음좌표에 벽 부수고 방문한 적도 없으면**:
    벽을 부순쪽의 visited배열 값을 현재 좌표값 + 1로 갱신해준다.
    그리고 덱에 (y, x, 1)을 삽입해 벽을 부쉈다고 알려준다
5. 마지막에 visited[n-1][m-1] 값을 확인해 최솟값을 구해준다.

4번에 visited[ny][nx][1]인 경우를 생각못해서 조금 애먹었네요 😂