### PR TITLE
[2021.07.29] 전진성 BOJ 2206, 7569

### DIFF
--- a/notCoderJ/dfs_bfs/2206.py
+++ b/notCoderJ/dfs_bfs/2206.py
@@ -1,0 +1,46 @@
+'''
+    풀이 요약
+        허허... 쉽게 생각하고 접근했다가 피봤네요...
+        벽 부순 경우랑 안 부순 경우를 한 맵 안에서 처리하려고 끝없이 시도하다가... 결국 포기하고
+        구글에서 힌트를 얻어 맵 두개로 분할해서 겨우 통과헀네요 ㅎㅎ
+        
+        일단 로직은 벽을 부순 맵이랑 안 부순 맵을 두개 만들어놓고
+        방문하지 않은 경로(통로이거나 벽이면 부순적 없는 경우)에 대해 탐색하면서
+        벽을 부순 경우는 벽을 부순 맵에 현재까지 이동 거리를 표기하고
+        벽을 부수지 않은 경우는 부수지 않은 맵에 이동 거리를 표기하며 bfs를 수행합니다.
+        두 경우 중 n, m의 위치에서 작은 값을 출력합니다.(단, 둘 중 하나가 0일 경우는 0이 아닌 값을, 둘 다 0인 경우는 -1을 출력합니다.)
+
+'''
+
+from collections import deque
+import copy
+import sys
+input = lambda: sys.stdin.readline().rstrip()
+INF = int(1e9)
+
+
+n, m = map(int, input().split())
+
+maze = [[] for _ in range(2)] # [0][][] : 벽 안부순 맵 / [1][][] : 벽 부순 맵
+for _ in range(n):
+    maze[0].append(list(map(int, input())))
+maze[1] = copy.deepcopy(maze[0])
+maze[0][0][0], maze[1][0][0] = 1, 1
+
+directions = [(-1, 0), (1, 0), (0, -1), (0, 1)]
+dq = deque([(0, 0, 0)]) # (x, y, break)
+chkDir = lambda x, y: True if 0 <= x < n and 0 <= y < m else False
+
+while dq:
+    x, y, br = dq.popleft()
+    
+    for dx, dy in directions:
+        nx, ny = x + dx, y + dy
+        # 범위 내에 있고 아직 방문하지 않았으며 통로이거나 벽일 경우 부순적 없는 경우
+        if chkDir(nx, ny) and (maze[br][nx][ny] == 0 or maze[br][nx][ny] == 1 and br == 0): 
+            cur = maze[br][nx][ny] or br
+            maze[cur][nx][ny] = maze[br][x][y] + 1
+            dq.append((nx, ny, cur))
+
+answer = list(filter(lambda x: x != 0, [maze[0][n - 1][m - 1], maze[1][n - 1][m - 1]]))
+print(min(answer + [INF])) if answer else print(-1)

--- a/notCoderJ/dfs_bfs/7569.py
+++ b/notCoderJ/dfs_bfs/7569.py
@@ -1,0 +1,48 @@
+'''
+    풀이 요약
+        지난 번 토마토 문제의 3차원 확장판이었기 때문에 간단하게 풀이했습니다.
+        앞뒤 고려사항이 추가된 것 외엔 지난 번 토마토와 동일하기 때문에 풀이 과정은 지난번과 같습니다.
+        
+        먼저 주어진 정보를 입력받으면서 익은 토마토의 좌표를 deque에 넣어두고 안익은 토마토의 갯수를 카운팅합니다.
+        그 후 deque이 빌 때까지 다음 과정을 반복 수행했습니다.
+            - deque에서 하나씩 꺼내어 상하좌우, 앞뒤에 있는 안익은 토마토에 대해 (해당 토마토 좌표, 현재일자 + 1) 값을 다시 deque에 넣어줍니다.
+            - deque에 넣어준 토마토는 값을 계산한 days로 바꾸어주어 재방문 하지 않도록 합니다.
+            - 안익은 토마토의 갯수를 1 감소시킵니다.
+'''
+
+from collections import deque
+import sys
+input = lambda: sys.stdin.readline().rstrip()
+
+
+days = 0
+dq = deque([])
+unripe = 0
+m, n, h = map(int, input().split())
+boxes = []
+for x in range(h):
+    boxes.append([])
+    for y in range(n):
+        boxes[-1].append([])
+        for z, v in enumerate(input().split()):
+            if v == '0':
+                unripe += 1
+            elif v == '1':
+                dq.append((x, y, z, 0))
+            boxes[-1][-1].append(v)
+            
+directions = [(0, -1, 0), (0, 1, 0), (0, 0, -1), (0, 0, 1), (1, 0, 0), (-1, 0, 0)] # 위 아래 왼쪽 오른쪽 앞 뒤
+chkDir = lambda x, y, z: True if 0 <= x < h and 0 <= y < n and 0 <= z < m else False # 방향 체크
+
+while dq and unripe:
+    x, y, z, d = dq.popleft()
+    
+    for dx, dy, dz in directions:
+        nx, ny, nz = x + dx, y + dy, z + dz
+        if chkDir(nx, ny, nz) and boxes[nx][ny][nz] == '0':
+            unripe -= 1
+            days = d + 1
+            boxes[nx][ny][nz] = days
+            dq.append((nx, ny, nz, days))
+
+print(days) if not unripe else print(-1)


### PR DESCRIPTION
### `2206: 벽 부수고 이동하기`
허허.... 처음에 쉽게 생각하고 접근했다가 한참 헤맸네요...😂
벽 부순 경우랑 안 부순 경우를 한 맵 안에서 처리하려고 끝없이 시도하다가... 결국 포기하고
구글님께 힌트를 얻어 맵 두개로 분할하는 방식으로 겨우 통과헀네요 ㅎㅎ
        
일단 로직은 벽을 부순 맵이랑 안 부순 맵을 두개 만들어놓고
방문하지 않은 경로(통로이거나 벽이면 부순적 없는 경우)에 대해 탐색하면서
벽을 부순 경우는 벽을 부순 맵에 현재까지 이동 거리를 표기하고
벽을 부수지 않은 경우는 부수지 않은 맵에 이동 거리를 표기하며 bfs를 수행합니다.
두 경우 중 n, m의 위치에서 작은 값을 출력합니다.(단, 둘 중 하나가 0일 경우는 0이 아닌 값을, 둘 다 0인 경우는 -1을 출력합니다.)


### `7569: 3차원 토마토`
지난 번 토마토 문제의 3차원 확장판이었기 때문에 간단하게 풀이했습니다. 앞뒤 고려사항이 추가된 것 외엔 지난 번 토마토와 동일하기 때문에 풀이 과정은 지난번과 같습니다.
        
먼저 주어진 정보를 입력받으면서 익은 토마토의 좌표를 deque에 넣어두고 안익은 토마토의 갯수를 카운팅합니다.
그 후 deque이 빌 때까지 다음 과정을 반복 수행했습니다.
- deque에서 하나씩 꺼내어 상하좌우, 앞뒤에 있는 안익은 토마토에 대해 (해당 토마토 좌표, 현재일자 + 1) 값을 다시 deque에 넣어줍니다.
- deque에 넣어준 토마토는 값을 계산한 days로 바꾸어주어 재방문 하지 않도록 합니다.
- 안익은 토마토의 갯수를 1 감소시킵니다.
