### PR TITLE
[2021.08.03] 이정규 BOJ 1504, 1717

### DIFF
--- a/JeongGod/1504.py
+++ b/JeongGod/1504.py
@@ -1,0 +1,55 @@
+'''
+방향성이 없는 그래프
+1번 정점 => n번 정점 최단 거리 이동(다익스트라)
+임의로 주어진 두 정점은 반드시 통과.
+
+다익스트라는 1 -> n번까지의 최단거리
+'''
+import sys,heapq,copy, math
+input = sys.stdin.readline
+
+N, E = map(int, input().split())
+graph = [[] for _ in range(N+1)]
+for i in range(E):
+    v1, v2, w = map(int, input().split())
+    graph[v1].append((v2,w))
+    graph[v2].append((v1,w))
+
+M1, M2 = map(int, input().split())
+
+# length 초기화.
+def initial(start, val):
+    return [math.inf if i != start else val for i in range(N+1)]
+
+def dijkstra(start, weight):
+    length = initial(start, weight)
+    hq = []
+    heapq.heappush(hq, (start, length[start]))
+    while hq:
+        cur, total_w = heapq.heappop(hq)
+        # 현재 저장된 cur까지가 최소라면 볼 필요가 없다.
+        if total_w > length[cur]:
+            continue
+
+        # cur정점에서 연결된 간선을 파악한다.
+        for next, nw in graph[cur]:
+            # cur를 거쳐 지나가는게 더 작다면
+            if length[next] > total_w + nw:
+                length[next] = total_w + nw
+                heapq.heappush(hq, (next, total_w+nw))
+    return length
+
+
+
+# 1에서 모든 경로 출발.
+first = dijkstra(1, 0)
+
+# 1 -> M1 -> M2
+second_M1 = dijkstra(M1, first[M1])
+third_M2 = dijkstra(M2, second_M1[M2])
+# 1 -> M2 -> M1
+second_M2 = dijkstra(M2, first[M2])
+third_M1 = dijkstra(M1, second_M2[M1])
+
+ans = min(third_M1[N], third_M2[N])
+print(-1 if ans == math.inf else ans)

--- a/JeongGod/1717.py
+++ b/JeongGod/1717.py
@@ -1,0 +1,39 @@
+import sys
+input = sys.stdin.readline
+
+n, m = map(int, input().split())
+
+tree = [i for i in range(n+1)]
+rank = [1 for i in range(n+1)]
+
+def find(root):
+    # 현재 노드가 부모노드라면
+    if tree[root] == root:
+        return root
+    
+    tree[root] = find(tree[root])
+    return tree[root]
+
+for i in range(m):
+    oper, x, y = map(int, input().split())
+    # 합집합
+    if oper == 0:
+        rx = find(x)
+        ry = find(y)
+        # 같은 합집합인 상태라면
+        if rx == ry:
+            continue
+        # 합치는데 rank를 기준으로 합친다.
+        if rank[rx] < rank[ry]:
+            tree[rx] = ry
+        else:
+            tree[ry] = rx
+            if rank[rx] == rank[ry]:
+                rank[rx] += 1
+
+    # 집합안에 있는지 출력
+    else:
+        rx = find(x)
+        ry = find(y)
+
+        print("YES" if rx == ry else "NO")

--- a/JeongGod/20168.py
+++ b/JeongGod/20168.py
@@ -1,0 +1,35 @@
+'''
+N개의 정점, M개의 간선
+1 -> dest까지 가야한다.
+최대 weight제일 작은 순으로 간다.
+    만약 해당 경로의 weight의 합이 수치심보다 크다면
+    다음 weight를 본다.
+
+'''
+
+import sys
+input = sys.stdin.readline
+
+n, m, start, dest, money = map(int, input().split())
+graph = [[] for i in range(n+1)]
+for i in range(m):
+    v1, v2, m = map(int, input().split())
+    graph[v1].append((m, v2))
+    graph[v2].append((m, v1))
+
+result = []
+def dfs(cur, total, max_money, visited):
+    if cur == dest:
+        result.append((max_money, total))
+    for nm, nv in graph[cur]:
+        # print(cur)
+        if nv not in visited:
+            dfs(nv, total+nm, max(max_money, nm), visited | {nv})
+
+dfs(1, 0, 0, {start})
+result.sort()
+for max_m, total in result:
+    if total <= money:
+        print(max_m)
+        exit()
+print(-1)

--- a/JeongGod/20168.py
+++ b/JeongGod/20168.py
@@ -29,5 +29,5 @@ def dfs(cur, total, max_money, visited):
         if nv not in visited:
             dfs(nv, total-nm, max(max_money, nm), visited | {nv})
 
-dfs(1, money, 0, {start})
+dfs(start, money, 0, {start})
 print(ans if ans != 1e9 else -1)

--- a/JeongGod/20168.py
+++ b/JeongGod/20168.py
@@ -18,18 +18,16 @@ for i in range(m):
     graph[v2].append((m, v1))
 
 result = []
+ans = 1e9
 def dfs(cur, total, max_money, visited):
+    global ans
+    if total < 0:
+        return
     if cur == dest:
-        result.append((max_money, total))
+        ans = min(max_money, ans)
     for nm, nv in graph[cur]:
-        # print(cur)
         if nv not in visited:
-            dfs(nv, total+nm, max(max_money, nm), visited | {nv})
+            dfs(nv, total-nm, max(max_money, nm), visited | {nv})
 
-dfs(1, 0, 0, {start})
-result.sort()
-for max_m, total in result:
-    if total <= money:
-        print(max_m)
-        exit()
-print(-1)
+dfs(1, money, 0, {start})
+print(ans if ans != 1e9 else -1)

--- a/JeongGod/9370.py
+++ b/JeongGod/9370.py
@@ -1,0 +1,96 @@
+import sys, heapq
+input = sys.stdin.readline
+
+tc = int(input())
+
+def dijkstra(start):
+    length = [1e9 for i in range(N+1)]
+    length[start] = 0
+    hq = [(start, 0)]
+    while hq:
+        cur, w = heapq.heappop(hq)
+
+        if w > length[cur]:
+            continue
+        for next, next_w in graph[cur]:
+            nw = next_w + w
+            if length[next] > nw:
+
+                length[next] = nw
+                heapq.heappush(hq, (next, nw))
+    return length
+
+for _ in range(tc):
+    flag = False
+    N, V, CN = map(int, input().split())
+    S, g, h = map(int, input().split())
+    graph = [[] for _ in range(N+1)]
+    for _ in range(V):
+        v1, v2, w = map(int, input().split())
+        graph[v1].append((v2,w))
+        graph[v2].append((v1,w))
+    candidates = [int(input()) for _ in range(CN)]
+    
+    # 출발지로부터 g, h로의 거리를 계산한다.
+    start_len = dijkstra(S)
+
+    # g, h로 다익스트라로 거리를 계산한다.
+    g_len = dijkstra(g)
+    h_len = dijkstra(h)
+    result = []
+
+    # 후보들과의 거리를 비교한다.
+    for cand in candidates:
+        if start_len[g] + g_len[h] + h_len[cand] == start_len[cand] or start_len[h] + h_len[g] + g_len[cand] == start_len[cand]:
+            result.append(cand)
+
+    print(*sorted(result))
+
+'''
+import sys, math, heapq
+input = sys.stdin.readline
+
+tc = int(input())
+
+def dijkstra(start):
+    length = [math.inf for i in range(N+1)]
+    length[start] = 0
+    hq = [(start, 0)]
+    while hq:
+        cur, w = heapq.heappop(hq)
+
+        if w > length[cur]:
+            continue
+        for next, next_w in graph[cur]:
+            nw = next_w + w
+            if length[next] > nw:
+
+                length[next] = nw
+                heapq.heappush(hq, (next, nw))
+    return length
+
+for _ in range(tc):
+    flag = False
+    N, V, CN = map(int, input().split())
+    S, g, h = map(int, input().split())
+    graph = [[] for _ in range(N+1)]
+    for _ in range(V):
+        v1, v2, w = map(int, input().split())
+        if (v1 == g and v2 == h) or (v1 == h and v2 == g):
+            graph[v1].append((v2,w-0.1))
+            graph[v2].append((v1,w-0.1))
+        graph[v1].append((v2,w))
+        graph[v2].append((v1,w))
+    candidates = [int(input()) for _ in range(CN)]
+
+    start_len = dijkstra(S)
+
+    result = []
+
+    # 후보들과의 거리를 비교한다.
+    for cand in candidates:
+        if start_len[cand] != math.inf and type(start_len[cand]) is float:
+            result.append(cand)
+
+    print(*sorted(result))
+'''    


### PR DESCRIPTION
### `1504 - 특정한 최단 경로`
시작점, 도착점의 최단 경로를 구하라고 해서 다익스트라로 구현하겠다고 생각했습니다.
그리고 두 개의 정점을 무조건 지나야 하고, 지났던 곳은 다시 가도 된다는 조건을 보고 다익스트라를 3번 사용하면 되겠다라고 마음먹고 짰습니다.

<풀이>
1. 시작점 "1"에서 다익스트라 알고리즘으로 최단거리를 구한다.
2. `1번`에서 구한 최단거리 중 거쳐야 하는 정점 [M1, M2]중 하나로 출발점을 잡고 다익스트라 알고리즘으로 최단거리를 구한다.
3. `2번`에서 구한 최단거리 중 정점 [M1, M2]중 거치지 않은 정점을 출발점으로 잡고 최단거리를 구한다.
4. `1 -> M1 -> M2 -> N`, `1 -> M2 -> M1 -> N`중에서 작은 값을 출력한다.

### `1717 - 집합의 표현`
처음에 대표 노드를 놓고 트리형식으로 하면 될 것 같았는데 어떻게 해야 할 지 감이 잡히지 않아 구글링을 했습니다.
크루스칼 알고리즘에서 쓰이는 Union-find 알고리즘을 공부하여 썼습니다.

<풀이>
1. 집합을 합친다면
   1. 합칠 집합 가장 최고인 부모를 찾습니다.
   2. 해당 부모가 같다면, 같은 집합내에 있다는 뜻이므로 진행하지 않습니다.
   3. 부모가 다르다면, Rank를 기준으로 합칩니다. 나중에 find할 때 이점을 주기 위해서입니다.
2. 같은 집합에 있는지 확인한다면
   1. 각 집합의 가장 최고인 부모를 찾습니다.
   2. 해당 부모가 같다면, 같은 집합내에 있다는 뜻입니다.
---

### `20168 - 골목 대장 호석`
dfs로 풀어봤는데 몇 개의 케이스에서 시간초과가 났는지 맞았지만 다 못 맞은 문제로 뜨네요.
문제 태그를 보니 백트래킹이라고 써있어서 조건을 추가하면 될 것 같은데 문제 풀어보고 해보겠습니다.

1.  모든 경우를 dfs로 탐색합니다.
2. 목적지에 도착했다면, 그 경로에서 제일 큰 비용과, 전체 비용을 result배열에 저장합니다.
3. 마지막에 result를 정렬한 후, 전체 비용과 현재 가지고 있는 비용을 비교합니다.

### `9370 - 미확인 도착지`
와.. 제 로직은 맞는거 같은데 왜 안풀리지 해서 구글링해서 답지와 비교해보고 난리를 쳤는데.. 문제는 이 녀석이였습니다.
```python
import math
math.inf
```
이건 그냥 무한대라 더해도 무한대이고, 빼도 무한대여서 비교할 수가 없었네요. 무한대표현을 이걸로 안하고 `sys.maxsize`로 대체하겠습니다 이젠..    
<풀이>
1. 시작점으로 부터 g,h까지의 최단거리를 구한다.
2. g,h각각 다익스트라로 모든 정점의 최단거리를 구한다.
3. g-h를 무조건 통과해야 하므로, 시작점에서 후보까지의 최단거리와 시작점 -> 'g' or 'h' -> 'h' or 'g' -> 후보 들을 비교하여 같으면 최단거리이므로 result에 추가한다.

한 2시간정도는.. 혼자서 싸맸네요.. 그리고 구글링하다가 아름다운 코드를 발견해서 밑에 추가했습니다.
<밑에 풀이>
1. g-h로 연결된 부분은 0.1씩 뺀다. 어차피 정수로 이루어져 있으니 weight에는 영향이 없다.
2. 시작점에서 후보군까지 최단거리를 구한다.
3. 만약 g-h를 통과한 곳이라면 정수가 아닌 소수점의 weight를 지니고 있을 것이다. 해당 후보군들을 답에 넣는다.


---
### `20168 - 골목 대장 호석`
dfs의 start부분이 문제였습니다.. 진성님이 말씀하신 시간복잡도도 잡고 여러가지 최적화를 좀 해봤습니다!