### PR TITLE
[2021.08.03] 전진성 BOJ 1504, 1717

### DIFF
--- a/notCoderJ/graph/1504.py
+++ b/notCoderJ/graph/1504.py
@@ -1,0 +1,60 @@
+'''
+    풀이 요약
+        처음에는 경로를 거쳐간다고 하여 플로이드 워셜을 생각했습니다.
+        하지만, 노드가 최대 800개라 3중 for문을 돌리면 터질 것이기 때문에 포기하였고
+        각각의 경로로 가는 최단 거리를 구해서 합하면 해당 지점을 거쳐가는 최단 거리가 나올 것이라 생각하여
+        각 지점에서 다익스트라를 수행 후 경로의 합이 최소인 지점을 선택하는 로직으로 설계하였습니다.
+'''
+
+import heapq
+import sys
+input = lambda: sys.stdin.readline().rstrip()
+INF = int(1e9)
+
+
+n, e = map(int, input().split())
+graph = [[] for _ in range(n + 1)]
+for _ in range(e):
+    a, b, c = map(int, input().split())
+    graph[a].append((b, c))
+    graph[b].append((a, c))
+
+n1, n2 = map(int, input().split())
+
+def dijkstra(s, d1, d2):
+    dist = [INF] * (n + 1)
+    dist[s] = 0
+    hq  = [(0, s)]
+    # stop = [False, False]
+    
+    while hq:
+        d, v = heapq.heappop(hq)
+        if d > dist[v]:
+            continue
+        # if v == d1:           # 하 한참해멨네요... 이 로직을 제거하니 통과되네요; 혹시 왜 그런지 아시는 분 계신가요??
+        #     stop[0] = True    # 꺼낸 정점이 해당 도착 지점인 경우 각각 True로 만들어줘서 두 도착 지점이 나오면 끝내게 하려는 목적이었습니다...
+        # elif v == d2:
+        #     stop[1] = True
+        # if all(stop):
+        #     break
+        
+        for nv, w in graph[v]:
+            next = d + w
+            if next < dist[nv]:
+                dist[nv] = next
+                hq.append((next, nv))
+
+    return (dist[d1], dist[d2])
+        
+isInvalid = lambda x, y: x == INF and y == INF
+
+p1 = dijkstra(1, n1, n2)
+p2 = dijkstra(n1, n2, n)
+p3 = dijkstra(n2, n1, n)
+
+if isInvalid(p1[0], p1[1]) or isInvalid(p2[0], INF) or isInvalid(p2[1], p3[1]):
+    print(-1)
+else:
+    path1 = p1[0] + p2[0] + min(p3[1], p2[0] + p2[1]) # 1 -> n1 -> min(n2 -> n, n2 -> n1 -> n)
+    path2 = p1[1] + p3[0] + min(p2[1], p3[0] + p3[1]) # 1 -> n2 -> min(n1 -> n, n1 -> n2 -> n)
+    print(min(path1, path2))

--- a/notCoderJ/graph/1717.py
+++ b/notCoderJ/graph/1717.py
@@ -1,0 +1,37 @@
+'''
+    풀이요약
+        합집합 연산과 같은 집합에 속해있는 지 확인하는 것으로 보아 서로소 집합 알고리즘이라는 것을 알았습니다.
+        그래서 주어진 합집합 연산에 대해서는 a, b를 합집합 연산해주었고 같은 집합에 속해있는지 확인하는 것은
+        두 노드의 루트 노드를 검색해서 사이클이 발생하는지 여부를 확인하여 판별했습니다.
+'''
+
+import sys
+input = lambda: sys.stdin.readline().rstrip()
+sys.setrecursionlimit(1000001)
+
+
+n, m = map(int, input().split())
+parent = [i for i in range(n + 1)]
+
+def find_root(a):
+    if a != parent[a]:
+        parent[a] = find_root(parent[a])
+    return parent[a]
+
+def union_set(a, b):
+    root_a = find_root(a)
+    root_b = find_root(b)
+    
+    if root_a > root_b:
+        parent[root_a] = root_b
+    else:
+        parent[root_b] = root_a
+
+isSameSet = lambda a, b: find_root(a) == find_root(b)
+
+for _ in range(m):
+    cal, a, b = map(int, input().split())
+    if cal == 0:
+        union_set(a, b)
+    else:
+        print("YES") if isSameSet(a, b) else print("NO")

--- a/notCoderJ/graph/20168.py
+++ b/notCoderJ/graph/20168.py
@@ -1,0 +1,44 @@
+'''
+    풀이 요약
+        다익스트라라고 보기엔 최단 거리를 구하는 문제가 아니어서 애매하긴 하지만, 풀이 과정이 유사한 것 같습니다.
+        
+        도로의 통행료 중 가장 싼 곳을 먼저 탐색하기 위해 최소 힙을 이용했습니다.
+        현재 지점에서 이동할 수 있는 다른 지점 중 도로의 통행료를 지불할 수 있는 지점에 대해서
+        [max(현재까지 중 가장 비싼 도로의 통행료, 다음 도로의 통행료) / 다음 지점 / 다음 지점으로 이동했을 때 남은 비용]을 힙에 넣어줍니다.
+        힙에서 꺼낸 지점이 도착 지점인 경우 해당 지점까지의 통행료 중 큰 값이 현재까지의 통행료(answer)보다 작다면 answer값을 갱신해줍니다.
+'''
+
+import heapq
+import sys
+input = lambda: sys.stdin.readline().rstrip()
+
+
+def solutions(start, dest, money, graph):
+    answer = 1001
+    hq = [(0, start, money)]
+
+    while hq:
+        c, n, r = heapq.heappop(hq)
+        if n == dest:
+            answer = min(answer, c)
+        
+        for v, w in graph[n]:
+            rest = r - w
+            if rest >= 0:
+                heapq.heappush(hq, (max(w, c), v, rest))
+        else:
+            graph[n] = [] # 방문 처리를 위해 해주었습니다.
+        
+    print(answer) if answer < 1001 else print(-1)
+
+
+if __name__ == "__main__":
+    N, M, A, B, C = map(int, input().split())
+    inter = [[] for _ in range(N + 1)]
+
+    for _ in range(M):
+        a, b, c = map(int, input().split())
+        inter[a].append((b, c))
+        inter[b].append((a, c))
+    
+    solutions(A, B, C, inter)

--- a/notCoderJ/graph/9370.py
+++ b/notCoderJ/graph/9370.py
@@ -1,0 +1,60 @@
+'''
+    풀이 요약
+        출발지점 1부터 주어진 도착지점까지 g, h를 거쳐서 가는 경로는 다음 2가지로 나눌 수 있습니다.
+            1) 1 -> g -> h -> dest
+            2) 1 -> h -> g -> dest
+        따라서, 1, g, h를 각각 출발점으로 하여 다익스트라를 수행한 후 도착 지점까지 구간별 최단 거리의 합을 구합니다.
+        최종 도착 지점들(dest)을 순회하며 앞서 구한 구간별 최단 거리의 합 중 최솟값과 1 -> dest로의 최단 거리가 일치한다면
+        해당 도착 지점을 유효 도착 지점(valid)에 넣어줍니다.
+'''
+import heapq
+import sys
+input = lambda: sys.stdin.readline().rstrip()
+INF = int(1e9)
+
+
+def execTest():
+    n, m, t = map(int, input().split())
+    s, g, h = map(int, input().split())
+    
+    graph = [[] for _ in range(n + 1)]
+    for _ in range(m):
+        a, b, d = map(int, input().split())
+        graph[a].append((b, d))
+        graph[b].append((a, d))
+    
+    dest = [int(input()) for _ in range(t)]
+
+    def dijkstra(start, dest):
+        dist = [INF for i in range(n + 1)]
+        dist[start] = 0
+        hq = [(0, start)]
+        
+        while hq:
+            d, v = heapq.heappop(hq)
+            if d > dist[v]: continue
+            
+            for nv, w in graph[v]:
+                next = d + w
+                if next < dist[nv]:
+                    dist[nv] = next
+                    hq.append((next, nv))
+        return {v: dist[v] for v in dest}
+    
+    path = dijkstra(s, dest + [g, h])
+    path1 = dijkstra(g, dest + [h])
+    path2 = dijkstra(h, dest + [g])
+
+    shortest = lambda x: min(path[g] + path1[h] + path2[x], path[h] + path2[g] + path1[x])
+    valid = []
+    for v in dest:
+        if shortest(v) == path[v]:
+            valid.append(v)
+
+    return sorted(valid)
+
+
+if __name__ == "__main__":
+    T = int(input())
+    for _ in range(T):
+        print(*execTest())


### PR DESCRIPTION
**`1504: 특정한 최단 경로`**
처음에는 경로를 거쳐간다고 하여 플로이드 워셜을 생각했습니다. 하지만, 노드가 최대 800개라 3중 for문을 돌리면 터질 것이기 때문에 포기하였고 각각의 경로로 가는 최단 거리를 구해서 합하면 해당 지점을 거쳐가는 최단 거리가 나올 것이라 생각하여 각 지점에서 다익스트라를 수행 후 경로의 합이 최소인 지점을 선택하는 로직으로 설계하였습니다. 그러나 코드를 짠 후 계속 실패가 나와서 구글링을 해보았는데 로직 자체가 동일하더라구요;
그래서 왜 안되지 고민하다가 플래그를 뒀던 것을 제거해보았는데 통과되네요;
아래 코드 line 34 ~ 39 주석 부분이에요... 혹시 왜 그런지 아시는 분 계신가요ㅠ?
line 58~59는 굳이 1 -> n1 -> n2 -> n1 -> n 이런 경우를 생각할 필요가 없었네요 이게 최단경로를 구하면 포함되서 나오는걸 미처 생각못했어요 ㅎㅎ;


**`1717: 집합의 표현`**
합집합 연산과 같은 집합에 속해있는 지 확인하는 것으로 보아 서로소 집합 알고리즘이라는 것을 알았습니다.
그래서 주어진 합집합 연산에 대해서는 a, b를 합집합 연산해주었고 같은 집합에 속해있는지 확인하는 것은
두 노드의 루트 노드를 검색해서 사이클이 발생하는지 여부를 확인하여 판별했습니다.


**`9370: 미확인 도착지`**
풀어보니 문제 유형은 어제 풀었던 <1504: 특정한 최단 거리>와 매우 비슷한 문제였습니다. 하지만, 처음에는 문제 자체가 잘 이해되지 않아 조금 헤맸습니다. 해당 경로를 거쳐가는 최단 거리를 구하라는 문제같긴 헀는데, 예시 1, 2번의 출력된 답이 잘 이해되지 않았습니다. 알고보니 포함해야하는 지점이 출발점에서 도착 예상 지점까지 최단 거리를 구했을 때 그 경로 안에 포함되어야 한다는 거였네요.(문제 이해도 참 중요한 것 같아요...)

출발지점 1부터 주어진 도착지점까지 g, h를 거쳐서 가는 경로는 다음 2가지로 나눌 수 있습니다.
1. 1 -> g -> h -> dest
2. 1 -> h -> g -> dest
따라서, 1, g, h를 각각 출발점으로 하여 다익스트라를 수행한 후 도착 지점까지 구간별 최단 거리의 합을 구합니다.
최종 도착 지점들(dest)을 순회하며 앞서 구한 구간별 최단 거리의 합 중 최솟값과 1 -> dest로의 최단 거리가 일치한다면 해당 도착 지점을 유효 도착 지점(valid)에 넣어줍니다.


**`20168: 골목 대장 호석 - 기능성`**
다익스트라라고 보기엔 최단 거리를 구하는 문제가 아니어서 애매하긴 하지만, 풀이 과정이 유사한 것 같습니다.
        
도로의 통행료 중 가장 싼 곳을 먼저 탐색하기 위해 최소 힙을 이용했습니다.
현재 지점에서 이동할 수 있는 다른 지점 중 도로의 통행료를 지불할 수 있는 지점에 대해서 max(현재까지 중 가장 비싼 도로의 통행료, 다음 도로의 통행료) / 다음 지점 / 다음 지점으로 이동했을 때 남은 비용]을 힙에 넣어줍니다.
힙에서 꺼낸 지점이 도착 지점인 경우 해당 지점까지의 통행료 중 큰 값이 현재까지의 통행료(answer)보다 작다면 answer값을 갱신해줍니다.
