### PR TITLE
[2021.08.05] 이정규 BOJ 1261, 13549

### DIFF
--- a/JeongGod/1261.py
+++ b/JeongGod/1261.py
@@ -1,0 +1,50 @@
+'''
+N*M의 크기
+
+빈방은 자유롭게 다닐 수 있다. 벽은 부숴야만 이동 가능
+
+무기를 이용해 벽을 부술수 있다.
+
+궁극의 무기를 이용해 벽을 한 번에 다 없애버릴 수 있다.
+
+1,1 -> N,M으로 이동하려면 몇 개의 벽을 부숴야 하나.
+
+100*100이다. -1,+1을 봐서 벽이면 부순다.
+
+---
+다익스트라로 벽을 부수지 않은 최단거리만 뽑아서 간다.
+'''
+import sys, heapq
+input = sys.stdin.readline
+
+n,m = map(int, input().split())
+
+board = [list(input().rstrip()) for i in range(m)]
+length = [[1e9]*n for i in range(m)]
+def dijstra():
+    dir = [(0,-1), (0,1), (1,0), (-1,0)]
+    hq = [(0, [0,0])]
+    length[0][0] = 0
+    
+    while hq:
+        wall_break, [cur_x, cur_y] = heapq.heappop(hq)
+        
+        # 최단거리가 이미 존재한다면 보지 않아도 된다.
+        if length[cur_y][cur_x] < wall_break:
+            continue
+        
+        # 답을 찾았다면
+        if cur_x == n-1 and cur_y == m-1:
+            return wall_break
+        
+        # 동서남북으로 봅니다.
+        for idx in dir:
+            next_x, next_y = cur_x+idx[0], cur_y+idx[1]
+            if 0 <= next_x < n and 0 <= next_y < m and board[next_y][next_x] != "-1":
+                if board[next_y][next_x] == "0":
+                    heapq.heappush(hq, (wall_break, [next_x, next_y]))
+                elif board[next_y][next_x] == "1" and length[next_y][next_x] > wall_break+1:
+                    heapq.heappush(hq, (wall_break+1, [next_x, next_y]))
+                board[next_y][next_x] = "-1"
+
+print(dijstra())

--- a/JeongGod/13549.py
+++ b/JeongGod/13549.py
@@ -1,0 +1,28 @@
+'''
+        걷는다면 1초후에 X-1 or X+1
+        순간이동 0초후에 2*X
+
+        수빈이가 동생을 찾을 수 있는 가장 빠른 시간
+'''
+import sys
+from collections import deque
+input = sys.stdin.readline
+
+visited = [1e9] * 100001
+
+start, dest = map(int, input().split())
+dq = deque([start])
+visited[start] = 0
+# 이동하는 거리를 계산합니다.
+def calc(x):
+    return [(x*2,0), (x-1,1), (x+1,1)]
+
+# BFS로 돌립니다.
+while dq:
+    cur = dq.popleft()
+    next = calc(cur)
+    for elem, cost in next:
+        if 0<= elem <= 100000 and visited[elem] == 1e9:
+            visited[elem] = min(visited[cur] + cost, visited[elem])
+            dq.append(elem)
+print(visited[dest])

--- a/JeongGod/13549.py
+++ b/JeongGod/13549.py
@@ -21,8 +21,10 @@ def calc(x):
 while dq:
     cur = dq.popleft()
     next = calc(cur)
+    if cur == dest:
+        break
     for elem, cost in next:
         if 0<= elem <= 100000 and visited[elem] == 1e9:
-            visited[elem] = min(visited[cur] + cost, visited[elem])
+            visited[elem] = visited[cur] + cost
             dq.append(elem)
 print(visited[dest])

--- a/JeongGod/TwoPointer/11659.py
+++ b/JeongGod/TwoPointer/11659.py
@@ -1,0 +1,13 @@
+import sys
+input = sys.stdin.readline
+
+n, m = map(int, input().split())
+
+_list = [0] + list(map(int, input().split()))
+
+for i in range(1, len(_list)):
+    _list[i] = _list[i-1]+_list[i]
+
+for _ in range(m):
+    i,j = map(int, input().split())
+    print(_list[j]-_list[i-1])

--- a/JeongGod/TwoPointer/1806.py
+++ b/JeongGod/TwoPointer/1806.py
@@ -1,0 +1,25 @@
+import sys
+input = sys.stdin.readline
+
+n, target = map(int, input().split())
+# a = input()
+_list = list(map(int, input().split()))
+
+part_len = 0
+ans = sys.maxsize
+start = 0
+part_sum = 0
+# 10만
+for i in range(len(_list)):
+    # 값이 작다면 더한다.
+    if part_sum < target:
+        part_sum += _list[i]
+        part_len += 1
+    # 값이 크다면 맨 앞에 있는 수를 빼준다.
+    while part_sum >= target and start <= i:
+        ans = min(ans, part_len)
+        part_sum -= _list[start]
+        part_len -= 1
+        start += 1
+
+print(ans if ans != sys.maxsize else 0)

--- a/JeongGod/TwoPointer/2470.py
+++ b/JeongGod/TwoPointer/2470.py
@@ -1,0 +1,28 @@
+'''
+<내 풀이>
+용액을 절댓값순으로 정렬한다.
+2개의 용액씩 비교하면서 제일 작은 값을 저장하면서 끝까지 간다.
+
+
+<투포인터 형식 풀이>
+용액을 오름차순으로 정렬한다.
+맨 왼쪽 용액과, 맨 오른쪽 용액을 처음 고른다. 그리고 그의 합을 구한다.
+만약 합이 음수라면
+    => 맨 왼쪽용액이 더 크다는 얘기. 그래서 왼쪽 용액을 작은애로 골라서 그 차이를 줄여본다.
+만약 합이 양수라면
+    => 맨 오른쪽 용액이 더 크다는 얘기. 그래서 오른쪽 용액을 더 작은애로 골라 그 차이를 줄여준다.
+'''
+import sys
+input = sys.stdin.readline
+
+n = int(input())
+
+_list = sorted(list(map(int, input().split())), key = lambda x : abs(x))
+
+ans = sys.maxsize
+for i in range(len(_list)-1):
+    if abs(_list[i] + _list[i+1]) < ans:
+        ans = abs(_list[i] + _list[i+1])
+        x, y = _list[i], _list[i+1]
+
+print(*sorted([x,y]))


### PR DESCRIPTION
### `1261 - 알고스팟` 
<문제>
무기를 이용하여 벽을 부술 수 있습니다.
빈방은 자유롭게 다닐 수 있습니다.

1,1 부터 N,M까지 가려면 벽을 최소 몇 개 부숴야하는지 출력하세요.
---
<풀이>
BFS와 비슷한 로직처럼 Dijkstra를 구현했습니다.
1. 가장 적게 벽을 부순 위치를 뽑습니다.
2. 상하좌우를 확인하여 가지 않은 곳을 확인합니다.
3. 벽을 부쉈는지 안 부쉈는지 판단하여 hq에 넣고 방문처리를 합니다.
4. 1번부터 반복하다, 만약 도착지점이 나왔다면 최소로 벽을 부수고 나온 것이므로 리턴합니다.

아마 BFS로도 구현이 가능할 것 같은데 처음 생각이 이거로 나서 짰습니다!

### `13549 - 숨바꼭질3` G5
start = 시작 위치, Dest = 목적지
<문제>
걷는다면 1초후에 X-1 or X+1의 위치로 이동.
순간이동을 한다면 0초후에 2*X의 위치로 이동

목적지에 가장 빠르게 도달하는 시간을 출력하세요.
---
<풀이>
BFS로 풀었습니다.
1. 처음 시작 위치를 넣습니다.
2. 처음 시작위치에서 +1, -1은 시간을 1초 늘리고, *2는 시간을 늘리지 않고 방문처리를 합니다.
3. 계속해서 1번을 반복하여 모든 곳을 다 방문합니다.
4. 답을 리턴합니다.

지금 보니깐 BFS라서 모든 경로를 보지 않아도 되고 도착지점에 도착하면 그게 최단거리라서 되네요. 전에 이렇게 짰었는데 왜 생각을 못하는지..  저 min하는것도 빼버려도 되네요..

---
### `1806 - 부분합 (진성님 문제)`
좀 많이 해멨네요.. 이거 밑에 2문제를 먼저 푼 뒤에 풀어서 그런지 어떻게 해야할 지 감이 잡혔던 것 같습니다.
실전에선 멘탈 나갈거같네요..

<풀이>
11659문제처럼 풀면 되겠다고 생각했습니다.
1. 먼저 start, end(여기서는 i)포인터를 정해 0,0으로 초기화합니다.
2. start ~ end까지 더한 합이 target보다 크다면, 지금까지의 구간의 길이를 저장합니다. 
그리고 나서 start를 한 칸 앞으로 옮겨 구간을 줄여나갑니다.
3. start ~ end까지 다한 합이 target보다 작다면, end를 한 칸씩 앞으로 늘립니다.

for, while이 두가지가 쓰여서 시간복잡도가 O(N^2)처럼 보일 수도 있습니다.
하지만 start, end포인터가 같이 움직여 나가는것으로 O(N+N)으로 O(2N) => O(N)으로 생각하는데 맞는지는 모르겠습니다..

### `2470 - 두 용액 (진성님 문제)`
저는 절댓값으로 sort하여 풀었습니다.
절댓값으로 sort했을 때, 두 용액의 부호가 다르다면 그게 두 용액의 차이가 제일 적은 것으로 생각했습니다.

<풀이>
1. 절댓값으로 sort한다.
2. 0,1 -> 1,2 -> 2,3 이렇게 용액들을 더해 가장 최소인 값을 찾는다.

### `11659 - 구간합 구하기 4 (진성님 문제)`
이게 투포인터를 배우기 위한 문제인 것 같습니다. 진성님 풀이와 같습니다ㅎㅎ
