### PR TITLE
[2021.08.09] 전진성 BOJ 10815, 16564(+엘리스 공굴리기)

### DIFF
--- a/notCoderJ/binary_search/10815.py
+++ b/notCoderJ/binary_search/10815.py
@@ -1,0 +1,63 @@
+'''
+    풀이 요약
+        음... 이 문제는 주어진 입력의 수가 최대 50만이고 중복되는 숫자 카드가 없으므로
+        간단히 집합 자료형을 이용한 순차 탐색으로 해결할 수 있다고 생각했습니다.
+        하지만, 이번주의 취지가 이분 탐색 알고리즘 능력을 향상시키기 위함이므로 이분 탐색을 구현해서도 풀어봤습니다.
+        총 3가지의 풀이 방식으로 풀었습니다.
+        
+        1. 집합 자료형을 이용한 순차 탐색 풀이
+            n개의 숫자에 대한 집합을 만들고 주어지는 m개의 숫자를 하나씩 순회하며 해당 집합에 들어있는지 확인하여 0 또는 1을 출력합니다.
+            
+        2. 직접 이분 탐색을 구현한 풀이
+            처음에는 이분 탐색 함수에 리스트를 슬라이싱하여 분할된 리스트를 매개 변수로 전달하는 방식으로 구현헀는데
+            슬라이싱 과정에서 시간이 많이 소요되어 시간 초과 판정을 받았습니다.
+            그래서 이분 탐색 함수에 시작, 끝 인덱스를 전달하고 해당 인덱스를 통해 중간 인덱스를 구하여 탐색하는 방법으로 다시 구현했습니다.
+            이 방법은 통과는 되었으나, 이분 탐색임에도 1번 알고리즘보다 효율성이 많이 떨어지더라구요... 아마 초기에 n개의 숫자를 정렬해야하기 때문인 것 같습니다.
+            
+        3. 이분 탐색 모듈(bisect)를 이용한 풀이
+            bisect 모듈을 간단히 설명하면
+                - bisect_left(리스트, 대상 값) : 매개 변수로 주어진 정렬된 리스트에 대상 값이 들어갈 좌측 인덱스를 반환합니다.
+                - bisect_right(리스트, 대상 값) : 매개 변수로 주어진 정렬된 리스트에 대상 값이 들어갈 우측 인덱스를 반환합니다.
+                ex) a = [1, 2, 6, 10]이 있을 때 bisect_left(a, 2) = 1 / bisect_right(a, 2) = 2를 반환합니다.
+            위처럼 반환되는 값을 이용해 좌측 != 우측인 경우 값이 존재한다고 판단하고, 좌측 == 우측인 경우 값이 존재하지 않는다고 판단하여 풀이했습니다.
+'''
+from bisect import bisect_left, bisect_right
+import sys
+input = lambda: sys.stdin.readline().rstrip()
+sys.setrecursionlimit(500001)
+
+
+def bSearch(target, start, end):
+    if start > end:
+        return False
+    
+    mid = (start + end) // 2
+    if nums[mid] == target:
+        return True
+    elif nums[mid] > target:
+        return bSearch(target, start, mid - 1)
+    else:
+        return bSearch(target, mid + 1, end)
+
+
+def lib_bSearch(target, nums):
+    if bisect_left(nums, target) != bisect_right(nums, target):
+        return True
+    else:
+        return False
+    
+
+if __name__ == "__main__":
+    n = int(input())
+    # nums = set(input().split())
+    nums = sorted(list(map(int, input().split())))
+    m = int(input())
+    
+    # for i in input().split():
+    #     print(1) if i in nums else print(0)
+    
+    # for i in map(int, input().split()):
+    #     print(1) if bSearch(i, 0, n - 1) else print(0)
+    
+    for i in map(int, input().split()):
+        print(1) if lib_bSearch(i, nums) else print(0)

--- a/notCoderJ/binary_search/16564.py
+++ b/notCoderJ/binary_search/16564.py
@@ -1,0 +1,28 @@
+'''
+    풀이 요약
+        주어진 N개의 수를 반씩 분할하여 경우의 수를 줄여나가는 이분 탐색의 원리를 활용했습니다.
+        이분 탐색처럼 반씩 분할하진 않지만 총 렙업 가능한 값(k)에서 인접한 렙업까지 필요한 값 * 렙업힐 케릭터 수를 계속 차감해주면서 k를 줄여 나갔습니다.
+        
+        인접한 두 레벨의 차이에 현재 인덱스 + 1(해당 레벨까지 렙업할 캐릭터 수를 의미)을 곱하여 이 값이 k보다 작으면 해당 값을 k에서 빼고 현재 최소 레벨(answer)을 둘 중 큰 레벨로 변경합니다. 만약 k보다 크거나 같다면 남은 k를 현재 렙업할 캐릭터 수로 나눈 몫을 현재 최소 렙에 추가하여 출력합니다.
+'''
+import sys
+input = lambda: sys.stdin.readline().rstrip()
+
+
+def goalLevel(n, k, levels):
+    answer = levels[0]
+
+    for i in range(n - 1):
+        upReq = (levels[i + 1] - levels[i]) * (i + 1)
+        if k > upReq:
+            k -= upReq
+            answer = levels[i + 1]
+        else:
+            answer += k // (i + 1)
+            return answer
+
+
+if __name__ == "__main__":
+    n, k = map(int, input().split())
+    levels = sorted([int(input()) for _ in range(n)])
+    print(goalLevel(n, k, levels))

--- a/notCoderJ/elice/rolling_ball.py
+++ b/notCoderJ/elice/rolling_ball.py
@@ -1,0 +1,35 @@
+'''
+    풀이 요약
+        테스트때는 반복구간에 대해 제대로 생각하지 못해서 다음 좌표가 이전 좌표가 될 경우만 있다고 생각하고 스택으로 접근했습니다.😅
+        물론 스택으로 풀어도 해당 좌표가 스택에 있는 지 검사하는 방법으로 풀 수 있다고 생각은 합니다.
+        하지만, 다시 풀어볼 때는 dfs를 이용한 방법으로 푸는 것이 더 깔끔할 것 같다고 생각하여 dfs로 풀어봤습니다.
+        
+        기저 조건
+            1. 현재 좌표가 구간을 벗어났으면 -1을 반환하고 종료
+            2. 현재 좌표를 방문한 적이 있다면 현재 좌표까지의 길이(i) - 방문 좌표까지의 길이(해당 방문 좌표를 key로 하는 값)
+        기저 조건에 해당하지 않으면 현재 좌표를 key로, 현재까지의 길이를 value로 해서 딕셔너리에 저장하여 방문처리하고
+        다음 이동 좌표에 대해 dfs 수행을 반복합니다.
+'''
+def main():
+    n, m = map(int, input().split())
+    dirs = {'1': (-1, 0), '2': (0, -1), '3': (0, 1), '4': (1, 0)}
+    maps = [''] + [[''] + input().split() for _ in range(n)]
+    y, x = map(int, input().split())
+    
+    
+    def repeatCnt(y, x, i, visited):
+        if y < 1 or y > n or x < 1 or x > m:
+            return -1
+            
+        if (y, x) in visited:
+            return i - visited[(y, x)]
+        
+        visited[(y, x)] = i
+        dy, dx = dirs[maps[y][x]]
+        return repeatCnt(y + dy, x + dx, i + 1, visited)
+
+    print(repeatCnt(y, x, 1, dict()))
+
+
+if __name__=="__main__":
+    main()


### PR DESCRIPTION
### `10815: 숫자 카드`
음... 이 문제는 주어진 입력의 수가 최대 50만이고 중복되는 숫자 카드가 없으므로 간단히 집합 자료형을 이용한 순차 탐색으로 해결할 수 있다고 생각했습니다. 하지만, 이번주의 취지가 이분 탐색 알고리즘 능력을 향상시키기 위함이므로 이분 탐색을 구현해서도 풀어봤습니다.

- 총 3가지의 풀이 방식으로 풀었습니다.
 1. 집합 자료형을 이용한 순차 탐색 풀이
 n개의 숫자에 대한 집합을 만들고 주어지는 m개의 숫자를 하나씩 순회하며 해당 집합에 들어있는지 확인하여 0 또는 1을 출력합니다.

2. 직접 이분 탐색을 구현한 풀이
처음에는 이분 탐색 함수에 리스트를 슬라이싱하여 분할된 리스트를 매개 변수로 전달하는 방식으로 구현헀는데, 슬라이싱 과정에서 시간이 많이 소요되어 시간 초과 판정을 받았습니다. 그래서 이분 탐색 함수에 시작, 끝 인덱스를 전달하고 해당 인덱스를 통해 중간 인덱스를 구하여 탐색하는 방법으로 다시 구현했습니다.
이 방법은 통과는 되었으나, 이분 탐색임에도 1번 알고리즘보다 효율성이 많이 떨어지더라구요... 아마 초기에 n개의 숫자를 정렬해야하기 때문인 것 같습니다.
            
3. 이분 탐색 모듈(bisect)를 이용한 풀이
bisect 모듈을 간단히 설명하면
- bisect_left(리스트, 대상 값) : 매개 변수로 주어진 정렬된 리스트에 대상 값이 들어갈 좌측 인덱스를 반환합니다.
- bisect_right(리스트, 대상 값) : 매개 변수로 주어진 정렬된 리스트에 대상 값이 들어갈 우측 인덱스를 반환합니다.
  ex) a = [1, 2, 6, 10]이 있을 때 bisect_left(a, 2) = 1 / bisect_right(a, 2) = 2를 반환합니다.
위처럼 반환되는 값을 이용해 좌측 != 우측인 경우 값이 존재한다고 판단하고, 좌측 == 우측인 경우 값이 존재하지 않는다고 판단하여 풀이했습니다.
추가) 이 방법은 함수를 한줄로 `lib_bSearch = lambda x, y: True if bisect_left(x, y) != bisect_right(x, y) else False`로도 쓸 수 있겠네요!

### `16564: 히오스 프로게이머`
 주어진 N개의 수를 반씩 분할하여 경우의 수를 줄여나가는 이분 탐색의 원리를 활용했습니다.
이분 탐색처럼 반씩 분할하진 않지만 총 렙업 가능한 값(k)에서 인접한 렙업까지 필요한 값 * 렙업힐 케릭터 수를 계속 차감해주면서 k를 줄여 나갔습니다.
        
인접한 두 레벨의 차이에 현재 인덱스 + 1(해당 레벨까지 렙업할 캐릭터 수를 의미)을 곱하여 이 값이 k보다 작으면 해당 값을 k에서 빼고 현재 최소 레벨(answer)을 둘 중 큰 레벨로 변경합니다. 만약 k보다 크거나 같다면 남은 k를 현재 렙업할 캐릭터 수로 나눈 몫을 현재 최소 렙에 추가하여 출력합니다.

### `공 굴리기`
엘리스 모의 코테때 잘못 생각해서 통과하지 못했던 문제를 풀고 추가해봤습니다.
마지막 문제도 풀지 못하긴 헀는데 차차 풀어보고 반영해보도록 하겠습니다.

- 기저 조건
1. 현재 좌표가 구간을 벗어났으면 -1을 반환하고 종료
2. 현재 좌표를 방문한 적이 있다면 현재 좌표까지의 길이(i) - 방문 좌표까지의 길이(해당 방문 좌표를 key로 하는 값)
기저 조건에 해당하지 않으면 현재 좌표를 key로, 현재까지의 길이를 value로 해서 딕셔너리에 저장하여 방문처리하고 다음 이동 좌표에 대해 dfs 수행을 반복합니다.
