### PR TITLE
[2021.08.12] 이정규 BOJ 3151, 7453, 13397, 20922

### DIFF
--- a/JeongGod/BinarySearch/13397.py
+++ b/JeongGod/BinarySearch/13397.py
@@ -1,0 +1,52 @@
+'''
+N = 5000, M = 5000
+최대 5000개를 포함한 배열을 만들 수 있다. 이 중 (최대 - 최소)의 값이 "최소"가 되게 만들어보자.
+
+임의로 만든 최솟값(tmp)을 생각해본다. (0 + 10000) // 2
+이 tmp값이 지금 구간으로 나눠보면 어떻게 되는지 판단해본다.
+1. 만약 구간으로 나눈 개수가 M보다 크다면
+    => 우리가 생각한 tmp값을 좀 더 늘려도 되겠다. 구간의 개수를 줄여야 답으로 인정받을 수 있으니깐.
+2. 만약 구간으로 나눈 개수가 M보다 작거나 같다면
+    => 조건에 부합하니 해당 tmp값을 임시로 답으로 지정해놓자.
+    그리고 tmp의 값이 더 작아도 이 조건에 부합하는지 판단해보자.
+'''
+import sys
+input = sys.stdin.readline
+
+N, M = map(int, input().split())
+_li = list(map(int, input().split()))
+
+left, right = 0, 10001
+result = 0
+# 우리가 (최대-최소)의 최댓값 tmp값을 임시로 정해보자.
+while left <= right:
+    tmp = (left+right) // 2
+    cnt = 1
+    min_val, max_val = sys.maxsize, -1
+
+    # tmp값으로 설정했을 경우 몇 개의 구간으로 나뉘어지는지 확인해보자.
+    for i in range(N):
+        max_val = max(max_val, _li[i])
+        min_val = min(min_val, _li[i])
+        # 해당 구간의(최대-최소)가 tmp보다 크다면 구간을 나눈다.
+        if max_val - min_val > tmp:
+            cnt += 1
+            min_val = _li[i]
+            max_val = _li[i]
+
+    '''
+    덜 쪼개지거나 같다면(cnt <= M)
+        가능한 경우다. 임시로 답을 지정해놓는다.
+        하지만 아직 더 볼 수 있는 경우가 있다. 우리는 "최소값"을 찾아야 한다.
+        그래서 tmp보다 작은 경우를 탐색한다.
+    많이 쪼개진다면
+        가능하지 않은 경우다. tmp가 너무 작다는 얘기다.
+        그래서 tmp의 값을 올려서 덜 쪼개지는 방향으로 탐색해야한다.
+    '''
+
+    if cnt <= M:
+        result = tmp
+        right = tmp-1
+    else:
+        left = tmp+1
+print(result)

--- a/JeongGod/BinarySearch/7453.py
+++ b/JeongGod/BinarySearch/7453.py
@@ -1,0 +1,49 @@
+import sys
+input = sys.stdin.readline
+
+N = int(sys.stdin.readline())
+A,B,C,D = [], [], [], []
+for i in range(N):
+    a,b,c,d = map(int, sys.stdin.readline().split())
+    A.append(a); B.append(b); C.append(c); D.append(d);
+
+A_B = {}
+for a_num in A:
+    for b_num in B:
+        ab_sum = a_num + b_num
+        
+        if A_B.get(ab_sum) == None:
+            A_B[ab_sum] = 1
+        else:
+            A_B[ab_sum] += 1
+ans = 0
+for c_num in C:
+    for d_num in D:
+        cd_sum = c_num + d_num
+        ans += A_B.get(-(c_num + d_num), 0)
+
+print(ans)
+
+# 이분탐색 실패
+# A_B = []
+# C_D = []
+# for idx1 in range(N):
+#     for idx2 in range(N):
+#         A_B.append(A[idx1] + B[idx2])
+#         C_D.append(C[idx1] + D[idx2])
+        
+
+# C_D.sort()
+
+# ans = 0
+# visited = set()
+# for num in A_B:
+#     # A_B => C_D check
+#     start = bisect.bisect_left(C_D, -num)
+#     # -num을 찾지 못하였다면
+#     if C_D[start] != -num:
+#         continue
+#     end = bisect.bisect_right(C_D, -num)
+#     print(start, end)
+#     ans += (end-start)
+# print(ans)

--- a/JeongGod/TwoPointer/20922.py
+++ b/JeongGod/TwoPointer/20922.py
@@ -1,0 +1,36 @@
+'''
+N = 200,000
+M = 100
+memory 1024MB
+1 second
+
+left, right잡는다. left = 0, right = 1
+right를 한 칸씩 옮기면서 개수를 센다. 개수는 defaultdict로 세자.
+그러다가 _dict[_li[right]] > k 가 된다면 _li[right]와 같은 숫자였던 처음 위치를 찾는다.
+left = (그 위치+1)로 삼고 right는 계속 옆으로 간다.
+'''
+import sys
+from collections import defaultdict
+input = sys.stdin.readline
+
+N, K = map(int, input().split())
+
+_li = list(map(int, input().split()))
+_dict = defaultdict(list)
+left = 0
+ans = 0
+for right in range(N):
+    # 현재 숫자
+    num = _li[right]
+    # key = 숫자, value = [index1, index2 ... ]
+    _dict[num].append(right)
+    
+    if len(_dict[num]) > K :
+        # 겹치는 친구의 index가 지금 left보다 작다면 지금 순열에 포함되지 않은 친구이다. pop해주고 넘어간다.
+        if _dict[num][0] < left:
+            _dict[num].pop(0)
+            continue
+        ans = max(ans, right-left)
+        left = _dict[num][0]+1
+        _dict[num].pop(0)
+print(max(ans, (right+1)-left))

--- a/JeongGod/TwoPointer/3151.py
+++ b/JeongGod/TwoPointer/3151.py
@@ -1,0 +1,41 @@
+import sys
+input = sys.stdin.readline
+
+N = int(input())
+students = list(map(int, input().split()))
+students.sort()
+ans = 0
+for i in range(N-2):
+    left = i+1
+    right = N-1
+    goal = -students[i]
+    while left<right:
+        tmp = students[left] + students[right]
+        if tmp < goal:
+            left += 1
+        elif tmp > goal:
+            right -= 1
+        else:
+            # 같은 것에서 2개를 뽑는 것 => nC2
+            if students[left] == students[right]:
+                k = right-left+1
+                tmp = (k*(k-1))//2
+                ans += tmp
+                break
+            # 중복이 있는지 체크한다.
+            else:
+                if mx_idx > right:
+                    mx_idx = right
+                    while mx_idx >= 0 and students[mx_idx - 1] == students[right]:
+                        mx_idx -= 1
+                ans += right - mx_idx + 1
+
+                # 시간초과 난 코드
+                # dup = 0
+                # for idx in range(right, left, -1):
+                #     if students[right] != students[idx]:
+                #         break
+                #     dup += 1 
+                # ans += dup
+            left += 1
+print(ans)


### PR DESCRIPTION
### `3151 - 합이 0`
처음에 투포인터 + 이분탐색으로 접근했는데 중복되는 값을 처리를 못 하겠더라구요.. 그래서 그냥 투포인터로만 풀었습니다.
중복처리에서 애를 많이 먹었네요. 시간초과를 어떻게 해결하나.. 하면서 많이 애먹고 결국 구글링해서 알아낸 문제입니다.
<풀이>
1. 먼저 투포인터를 사용하기 위해 sort를 합니다.
2. "i"번째 학생을 선택했을 경우의 값을 goal로 설정한다면 `left번쨰 학생 + right번째 학생 + goal == 0`을 찾도록 합니다. 
3. 저 위의 식을 생각하면 `left + right = -goal`로 놓고 left + right값을 비교해나가면서 포인터를 이동시킵니다.
4. 만약 left ~ right까지 모든 학생이 같다면 조합을 생각했습니다. 같은 것에서 2개를 뽑는 것이니 조합식을 이용하여 구현했습니다.
`nCr = n! // (n-r)! r!`
5. 그리고 부분적으로 같은 값을 가지고 있는지 확인합니다.

- 저 시간초과난 코드는 right에서 이미 중복을 검사했다면, 다시는 검사하지 않아도 되지만 계속해서 검사하다보니 시간초과가 났습니다.


### `20922 - 겹치는 건 싫어`
<풀이>
1. list를 돌면서 숫자와 그 숫자가 있는 index를 받아옵니다.
2. dict에 key를 숫자로 하여금 index를 넣습니다. dick[num] 에 있는 list의 길이는 곧 num의 개수입니다.
3. 만약 현재 순열에서 num의 개수가 k개를 넘어가는 부분이라면 현재 left(수열의 시작부분)와 비교합니다. left보다 작다면 순열에 포함되지 않는 부분이므로 해당 index를 제외하고 다음 반복문으로 넘어갑니다.
4. 그리고 k개를 넘어간 부분이 순열의 끝이므로 최댓값을 갱신해준다.

### `7453 - 합이 0인 네 정수`
이 문제는 허허.. 파이썬으로는 풀지마라 하는 문제같아요. 이분탐색으로 접근했었는데 시간초과가 뜨더라구요. 그냥 다 안됩니다. 풀이방법은 파이썬으로는 이렇게 풀 수 밖에 없는 것 같네요.
지금 이렇게 최적화해도 10~11초로 간당간당하게 통과됩니다.

<풀이>
1. list A,B를 더한 값과 list C,D를 각각 따로 더한다.
2. A,B에서 더한 값을 dict의 key로 놓고 개수를 센다.
3. C,D에서 더한 값의 부호를 바꾼 값이 dict에 key에 있는지 판단한다. 있다면 두 개를 곱한 경우가 곧 경우의 수이다.

<이분탐색 풀이>
1. list A,B를 더하고(A_B), list C,D를 더해서(C_D) 저장해놓는다.
2. A_B의 값을 하나씩 보면서 부호의 반대인 값을 C_D에서 이분탐색으로 찾는다.
3. 여기서 중복되는 값이 있을 수도 있기에 bisect를 이용하여 탐색한다.
bisect_left는 해당 -num이 들어갈 자리의 왼쪽 자리의 index를 반환합니다.
bisect_right는 해당 -num이 들어갈 자리의 오른쪽 자리의 index를 반환합니다.

### `13397 - 구간 나누기2`
이거는 도저히 생각이 나질 않았습니다. 로직을 봐도 모르겠어서 결국 정답 코드를 보고 이해하기만 했네요..

<풀이>
1. 최소값은 1~10000사이이므로 최솟값과 최댓값을 임시로 답을 지정해놓고 맞는지 확인해본다.
2. 확인하는 과정은 해당 tmp값이 정답일 경우에 구간이 몇 개의 구간으로 나누어지는지 확인해본다.
3. 2가지의 경우로 나뉘어진다.
- 나누어진 구간의 개수가 M보다 작거나 같다면
  - 가능한 경우. 그래서 tmp를 답으로 정해놓고 더 최솟값을 찾는게 목표니 더 작은 값에서 찾아본다.
- 나누어진 구간의 개수가 M보다 크다면
  - 불가능한 경우. tmp값이 너무 작은 경우다. tmp값을 늘려서 구간의 개수를 줄여야 한다.
