### PR TITLE
[2021.09.09] 이정규 Programmers 가장 큰 수, 메뉴 리뉴얼

### DIFF
--- a/JeongGod/programmers/kakao/biggest.py
+++ b/JeongGod/programmers/kakao/biggest.py
@@ -1,0 +1,19 @@
+def solution(numbers):
+
+    # 모두 4자리로 만들어준다.    
+    result = []
+    for num in numbers:
+        tmp = str(num)
+        tmp += tmp*3
+        result.append((tmp[:4], str(num)))
+    
+    # 4자리수로 sort한다. 만약 4자리수가 같다면, 기존에 있던 수로 비교를 한다.
+    result = sorted(result, key=lambda x : (int(x[0]), int(x[1])), reverse=True )
+
+    # 예외처리
+    if result[0][1] == '0':
+        return '0'
+    
+    answer = ''.join([x[1] for x in result])
+
+    return answer

--- a/JeongGod/programmers/kakao/menu.py
+++ b/JeongGod/programmers/kakao/menu.py
@@ -28,6 +28,23 @@ def solution(orders, course):
         if len(menu) in course_dict and cnt >= course_dict[len(menu)]:
             course_dict[len(menu)] = cnt
             answer.append(''.join(menu))
-    print(results) 
-    print(answer)
+
     return sorted(answer)
+
+## Counter 사용
+import collections
+import itertools
+
+
+def solution(orders, course):
+    result = []
+
+    for course_size in course:
+        order_combinations = []
+        for order in orders:
+            order_combinations += itertools.combinations(sorted(order), course_size)
+
+        most_ordered = collections.Counter(order_combinations).most_common()
+        result += [ k for k, v in most_ordered if v > 1 and v == most_ordered[0][1] ]
+
+    return [ ''.join(v) for v in sorted(result) ]

--- a/JeongGod/programmers/kakao/menu.py
+++ b/JeongGod/programmers/kakao/menu.py
@@ -1,0 +1,33 @@
+from collections import defaultdict
+from itertools import combinations
+
+
+def solution(orders, course):
+    '''
+    가장 많이 함께 주문한 단품메뉴들을 코스요리 메뉴로 구 성
+    2가지 이상, 2명 이상의 주문의 단품메뉴 후보
+    '''
+    _dict = defaultdict(int)
+    # 손님이 시킨 메뉴에서 모든 조합을 알아본다.
+    for order in orders:
+        for n in course:
+            for i in combinations(sorted(list(order)), n):
+                _dict[i] += 1
+
+    results = sorted(_dict.items(), key=lambda x: x[1], reverse=True)
+    # "오름차순"으로 주어진다고 했으므로 course[-1]이 최댓값
+    course_dict = defaultdict(int)
+    for num in course:
+        # 최소 2명 이상의 손님에게 주문받은것만 가능
+        course_dict[num] = 2
+
+    answer = []
+    for menu, cnt in results:
+
+        # 먼저 course에 해당하는 개수인지 확인 => 현재 course에서 요구하는 최대메뉴가 맞는지 확인
+        if len(menu) in course_dict and cnt >= course_dict[len(menu)]:
+            course_dict[len(menu)] = cnt
+            answer.append(''.join(menu))
+    print(results) 
+    print(answer)
+    return sorted(answer)


### PR DESCRIPTION
### `lv2 - 가장 큰 수`
테케 1~6번인 틀려서 엄청 고생했네요.. 왜 틀리는지 아직도 이해가 안가서 일단 푸쉬해놓고 이해해보겠습니다.
제가 생각했던 방법은 원래 **맨 앞자리의 수**를 하나씩 더해가며 4자리를 만드는 것이였습니다.
[6, 10, 2] => [6666, 1011, 2222] 이렇게요.
그런데 이렇게 하면 틀리고 기존에 있던 숫자를 계속해서 붙여나가는 느낌으로
[6, 10, 2] => [6666, 1010, 2222] 이렇게 하면 맞더라구요. 뭔 차인지.. 아직 모르겠습니다.

<풀이>
1. 수를 비교하기 위해서 같은 자릿수로 만듭니다. 현재 문제에서 1000이 수의 최대라고 했으니 4자리로 만들어줍니다.
2. 그 뒤에, 4자리로 만든 숫자를 비교합니다. 만약에 같다면 만들기 전에 숫자가 더 큰 순으로 정렬합니다.
3. 정렬한 배열을 하나씩 붙여나갑니다.

### `lv2 - 메뉴 리뉴얼`
구현 문제네요. 제 방식은 테케에서 2초정도 걸리는 케이스도 있습니다. 모든 경우의 조합을 다 구하다보니 그런 것 같아요.
만약에 밑에 Counter풀이처럼 해당 조합의 경우만 본다면 확실히 시간이 줄어듭니다.
Counter사용 풀이도 밑에 적어놓았습니다.

<풀이>
1. 손님이 시킨 메뉴의 조합을 모두 구합니다. 구한 조합을 모두 dict에 담습니다. (key = 조합, value = 해당 조합을 시킨 횟수)
2. (key, value)로 가져오는데 value값으로 sort를 진행합니다.
3. sort를 한 리스트들을 하나씩 흝으면서 담습니다.
담는 기준은 course에서 요구하는 조합의 길이와 맞고, 그 해당 조합을 시킨 횟수가 최대인지 확인하고 담습니다.

<Counter 풀이>
1. 손님이 시킨 메뉴의 조합을 course에서 요구한 조합을 하나씩 구한 뒤 list에 담습니다. (여기서 시간이 많이 단축되네요. 저는 모든 것을 보지만 여기선 해당 사항만 봅니다.)
2. list를 Counter안에 넣어 해당 조합을 시킨 횟수를 바로 구하고 정렬합니다. (key = 조합, value = 해당 조합을 시킨 횟수)
3. 그 뒤에 (2<= n <= 최고 횟수)를 만족하면 result에 넣습니다.