### PR TITLE
[2021.09.09] 박지윤 - 프로그래머스 가장 큰 수, 메뉴 리뉴얼

### DIFF
--- a/JYP/Programmers_test_kit/sort_max_number.py
+++ b/JYP/Programmers_test_kit/sort_max_number.py
@@ -1,0 +1,26 @@
+from collections import defaultdict
+
+def solution(numbers):
+
+    if set(numbers) == {0}:
+        return '0'
+    
+    keys = defaultdict(int)
+    for num in numbers:
+        first_digit = int(str(num)[0])
+
+        if first_digit in keys:
+            keys[first_digit].append(num)
+        else:
+            keys[first_digit] = [num]
+
+    keys = sorted(dict.items(keys), reverse=True)
+
+    answer = ""
+    for key in keys:
+        temp = sorted(key[1], key=lambda x: str(x)*3, reverse=True)
+        for num in temp:
+            answer += str(num)
+            
+
+    return answer

--- a/JYP/kakao_blind/2021_menu_renewal.py
+++ b/JYP/kakao_blind/2021_menu_renewal.py
@@ -1,0 +1,21 @@
+from collections import Counter
+from itertools import combinations
+
+def solution(orders, course):
+
+    temp = [[]*i for i in range(len(course))]
+    for order in orders:
+        order = sorted(list(order))
+        i = 0
+        for num in course:
+            temp[i] += list(map(''.join, combinations(order, num)))
+            i += 1
+            
+    answer = []
+
+    for combination in temp:
+        count = Counter(combination)
+        arr = [k for k, v in count.items() if max(count.values())==v and v > 1]
+        answer += arr
+
+    return sorted(answer)


### PR DESCRIPTION
## 가장 큰 수   
`설명`
- defaultdict를 이용하여 첫째 자리 숫자로 각각 다른 그룹을 지어주었어요.
- 그 다음 첫째 자리 숫자에 따라 정리된 그룹을 내림차순으로 sort했습니다. (예: [9, 91, 90], [7, 77, 733], ..., [1, 187] 순서)
- 그리고 각 그룹 내에서 sort를 다시 진행했습니다. 여기서 제일 헤맸는데요,
- 처음 생각했던 로직은 첫째 자리 숫자를 key로 하고 각 그룹의 최고 자리 숫자 길이(입력값이 1000이하라는 걸 잊고 있었어요)에 비교하여 보정한 뒤 각 값을 비교하는 거였습니다. 
- 예를 들면, 41과 412가 입력값이라면 결과는 41412가 되어야 하는데, 이를 위해 41을 414로 보정한 뒤 412와 비교해보려고 했습니다. 코드 구현이 잘 안되어서 이 부분은 결국 실패했어요. 
- 41을 414로 보정하는 로직은 가장 큰 수와의 자릿수 차이만큼 4(최고 자리 숫자)를 계속 붙여주는 방식이었어요.


`어려웠던 점`   
- 입력 조건을 제대로 보지 않아서 한참 고생했습니다^^;
- 최댓값이 1000밖에 되지 않는데 자릿수 보정에 대해서 오래 고민하고 있어서 시간을 많이 잡아먹었습니다. 조건을 꼼꼼히 따져봐야겠어요...


`알게된 점`
- 디스코드에서 다른 분들께서 말씀해주신덕분에 파이썬에서 문자열과 정수형의 대소 비교의 차이에 대해 이해할 수 있었습니다. 

<br>
<br>

## 메뉴 리뉴얼   
`설명`   
- 빈도 수 체크를 위해 Counter객체를 사용했습니다. 
- 희지님께서 올려주신 리스트 컴프리헨션을 적용해보았습니다. 길게 썼던 코드가 한 줄로 줄어들고 나머지를 싹 지워버릴 때의 쾌감이 있네요 ㅎㅎ
- 마찬가지로 다른 분들 풀리퀘스트 내용을 많이 참고했습니다. 
- 메뉴 조합의 빈도를 고민하니 문제가 금방 풀렸습니다. 

`어려웠던 점`
- 한참 고민하다가 잘 시간을 너무 넘겨서 결국 다른 분들 풀리퀘스트 보고 방법을 이해했습니다.^^; 문제 이해가 가장 어려운 거네요...
- 커밋하지 않은 실패 케이스에서는 각 알파벳의 빈도를 곧바로 Counter로 받은 뒤 조합을 하려고 했습니다. 그러다보니 조합의 경우의 수가 너무 복잡해져서 코드를 설계하는 시간이 너무 많이 걸렸어요. 메뉴 조합의 빈도를 생각해야 하는데 너무 작은 단위에서 출발해서 문제가 생긴 것 같습니다. 조합을 사용하면 항상 시간 초과가 걸려서 잘 안 쓰려고 하는데 이 문제는 결국 조합을 써야 하는 문제였고, 생각해보니 문제에서 제시하는 입력값이 다른 문제에 비해서는 상당히 작기 때문에 좀 더 과감하게 생각해도 되었을 거 같아요. 

`알게된 점`
- 리스트 컴프리헨션! 

<br>
<br>

### ?
- 풀 리퀘스트 이렇게 하는 게 맞나요?.?
