### PR TITLE
[2021.09.10] 임희지 programmers 순위 검색

### DIFF
--- a/limhizy15/two_pointer/pro_72412.py
+++ b/limhizy15/two_pointer/pro_72412.py
@@ -1,0 +1,51 @@
+# 2021 kakao 순위 검색
+
+from collections import defaultdict
+from itertools import combinations
+from bisect import bisect_left
+
+# info - 4가지 정보 + 점수, query - 문의조건
+def solution(info, query):
+    answer = []
+    info_dict = defaultdict(list)
+    
+    # 정보 가공
+    for i in info:
+        temp = i.split(' ')
+        four_infos = temp[:-1] # 4가지 정보
+        score = int(temp[-1]) # 점수
+        
+        # 4가지 정보로 가능한 모든 조합을 만들어 딕셔너리의 키값으로 활용
+        for k in range(5):
+            for comb in combinations(four_infos, k):
+                info_dict[''.join(comb)].append(score)
+    
+    # 이진 탐색을 위한 정렬
+    for v in info_dict.values():
+        v.sort()
+    
+    # 쿼리 가공
+    for q in query:
+        num = 0
+        
+        temp = q.split(' ')
+        q_infos = temp[:-1]
+        q_score = int(temp[-1])
+        
+        q_string = ''.join(q_infos)
+        
+        # and와 - 제거 
+        q_string = q_string.replace('and', '')
+        q_string = q_string.replace('-', '')
+        
+        # 그냥 탐색할 때 시간초과
+        # 이진탐색 참고 - https://esoongan.tistory.com/119
+        if q_string in info_dict:
+            score_list = info_dict[q_string]
+            # target 점수의 index를 찾은 후 전체 길이에서 index만큼 빼줌
+            index = bisect_left(score_list, q_score)
+            answer.append(len(score_list) - index)
+        else:
+            answer.append(0)
+    
+    return answer


### PR DESCRIPTION
### `순위 검색`
#### 생각
- 일단 가능한 정보의 조합을 구하고 이걸 key, 해당 조합에 속하는 점수를 value로 해서 딕셔너리를 만들면 찾을 때 쉽겠다 생각했습니다. 근데 이제 query로 조건에 맞는 것을 셀 때 효율성에서 계속 시간 초과가 나더라구요.. 20분 머리 싸매다가 검색해보니 이진 탐색으로 해결해야한다는 걸 알았습니다. 근데 이진탐색을 어떻게 하는지 기억이 안나서 일단 따라쳤어요.. 😂

#### 풀이
1. info의 원소를 4가지 정보 / 점수로 분리하고, 4가지 정보로 가능한 모든 조합을 구합니다. (0, 1, .., 4개를 고르는 경우의 수) 이 조합을 key로 하고 점수를 value list에 넣었습니다.
2. 후에 이진탐색하기 위해 value list를 정렬했습니다.
3. 쿼리도 info를 변경하는 것과 동일합니다. 다만 여기선 'and'와 '-'가 있기 때문에 이걸 replace 메서드로 없애주었어요.
4. 이제 3번에서 이쁘게 가공된 쿼리를 key로 하는 딕셔너리 원소가 존재하는지 확인합니다. 존재하지 않으면 0개이므로 0을 정답에 넣어줍니다. 
5. 존재하면 value들 중에서 찾고자하는 점수를 기준으로 이진탐색을 해서 인덱스를 찾아냅니다. 이제 그 이상인 점수를 구해야하니까 value의 원소 개수에서 인덱스를 빼면 타겟 점수 이상인 원소의 개수가 나옵니다. 
- bisect_left를 쓴 이유가 아마 타겟 점수가 없으면 그거 왼쪽에 있는 애를 리턴해서 그런 것 같아요.. 사실 아직 이진탐색을 잘 이해못해서 그런갑다한 상태이고 풀리하고 조금 더 찾아보려합니다