### PR TITLE
[2021.09.10] 전진성 프로그래머스 2021 카카오 블라인드 순위 검색(lv2)

### DIFF
--- a/notCoderJ/kakao/rank.py
+++ b/notCoderJ/kakao/rank.py
@@ -15,37 +15,77 @@
 '''
 
 from bisect import bisect_left
+from collections import defaultdict
 
 def solution(info, query):
-    answer = [0] * len(query)
-    # lang job career food
-    #  000  00     00   00
-    table = {
-        'cpp': 256,
-        'java': 128,
-        'python': 64,
-        'backend': 32,
-        'frontend': 16,
-        'junior': 8,
-        'senior': 4,
-        'chicken': 2,
-        'pizza': 1,
-    }
-    
-    ap_cnt = [[] for _ in range(512)]
-    ap_info = map(lambda x: x.split(), info)
-    
-    for i, ap_if in enumerate(ap_info):
-        ap_cnt[sum(map(lambda x: table[x], ap_if[:-1]))].append(int(ap_if[-1]))
-    
-    ap_cnt = [(i, sorted(v))  for i, v in enumerate(ap_cnt) if v]
-    require = map(lambda x: x.replace('and', '').replace('-', '').split(), query)
+  answer = [0] * len(query)
+  # 000 00 00 00
+  table = {
+      'cpp': 64,
+      'java': 128,
+      'python': 256,
+      'backend': 16,
+      'frontend': 32,
+      'junior': 4,
+      'senior': 8,
+      'chicken': 1,
+      'pizza': 2,
+      '-': 0,
+  }
+  
+  ap_cnt = defaultdict(list)
+  ap_info = sorted(map(lambda x: x.split(), info), key=lambda x: int(x[-1]))
+  
+  def comb(cnt, items):
+      if cnt == 0:
+          return {sum(items)}
+      next = cnt - 1
+      return comb(next, items) | comb(next, items[:next] + [0] + items[cnt:])
+  
+  for *rest, score in ap_info:
+      for case in comb(4, list(map(lambda x: table[x], rest))):
+          ap_cnt[case].append(int(score))
+  require = map(lambda x: x.replace('and', '').split(), query)
 
-    for i, req in enumerate(require):
-        q = sum(map(lambda x: table[x], req[:-1]))
-        for j, v in ap_cnt:
-            if j & q == q:
-                idx = bisect_left(v, int(req[-1]))
-                answer[i] += len(v[idx:])
-        
-    return answer
+  for i, req in enumerate(require):
+      q = sum(map(lambda x: table[x], req[:-1]))
+      idx = bisect_left(ap_cnt[q], int(req[-1]))
+      answer[i] = len(ap_cnt[q]) - idx
+
+  return answer
+
+  
+# 이전 코드
+# def solution(info, query):
+#   answer = [0] * len(query)
+#   # lang job career food
+#   #  000  00     00   00
+#   table = {
+#       'cpp': 256,
+#       'java': 128,
+#       'python': 64,
+#       'backend': 32,
+#       'frontend': 16,
+#       'junior': 8,
+#       'senior': 4,
+#       'chicken': 2,
+#       'pizza': 1,
+#   }
+  
+#   ap_cnt = [[] for _ in range(512)]
+#   ap_info = map(lambda x: x.split(), info)
+  
+#   for i, ap_if in enumerate(ap_info):
+#       ap_cnt[sum(map(lambda x: table[x], ap_if[:-1]))].append(int(ap_if[-1]))
+  
+#   ap_cnt = [(i, sorted(v))  for i, v in enumerate(ap_cnt) if v]
+#   require = map(lambda x: x.replace('and', '').replace('-', '').split(), query)
+
+#   for i, req in enumerate(require):
+#       q = sum(map(lambda x: table[x], req[:-1]))
+#       for j, v in ap_cnt:
+#           if j & q == q:
+#               idx = bisect_left(v, int(req[-1]))
+#               answer[i] += len(v[idx:])
+      
+#   return answer

--- a/notCoderJ/kakao/rank.py
+++ b/notCoderJ/kakao/rank.py
@@ -1,0 +1,52 @@
+'''
+  풀이요약
+    bit 연산을 이용하기 위해 bit 테이블을 만들어서 이용했습니다.
+    1. 가능한 선택지에 대해 종류별로 1bit씩 할당해서 아래와 같이 자리값을 지정합니다.
+      언어는 최상위 3bit
+      직종은 다음 상위 2bit
+      경력은 그다음 상위 2bit
+      음식은 최하위 2bit
+    2. 주어진 info의 각 항목들을 해당 테이블을 이용해 값으로 치환해서 모두 더한 후
+      그 값을 ap_cnt의 인덱스로 하여 코딩 테스트 점수를 추가합니다.
+    3. 2에서 채워진 ap_cnt의 빈 값들을 모두 제거하고, (인덱스, 점수의 sorting 값) 형태로 변환합니다.
+    4. 주어진 query를 파싱해서 2번과 같이 table을 이용해 위치 값으로 치환한 후
+      해당 값과 ap_cnt의 인덱스를 and연산해서 query의 위치값과 동일한 경우
+      이진 탐색을 이용해 현재 query의 점수보다 큰 점수의 갯수를 구해 해당 answer자리에 더해줍니다.
+'''
+
+from bisect import bisect_left
+
+def solution(info, query):
+    answer = [0] * len(query)
+    # lang job career food
+    #  000  00     00   00
+    table = {
+        'cpp': 64,
+        'java': 128,
+        'python': 256,
+        'backend': 16,
+        'frontend': 32,
+        'junior': 4,
+        'senior': 8,
+        'chicken': 1,
+        'pizza': 2,
+    }
+    
+    ap_cnt = [[] for _ in range(512)]
+    ap_info = map(lambda x: x.split(), info)
+    
+    for i, ap_if in enumerate(ap_info):
+        ap_cnt[sum(map(lambda x: table[x], ap_if[:-1]))].append(int(ap_if[-1]))
+    
+    ap_cnt = [(i, sorted(v))  for i, v in enumerate(ap_cnt) if v]
+    require = map(lambda x: x.replace('and', '').replace('-', '').split(), query)
+
+    for i, req in enumerate(require):
+        q = sum(map(lambda x: table[x], req[:-1]))
+        qualified = []
+        for j, v in ap_cnt:
+            if j & q == q:
+                idx = bisect_left(v, int(req[-1]))
+                answer[i] += len(v[idx:])
+        
+    return answer

--- a/notCoderJ/kakao/rank.py
+++ b/notCoderJ/kakao/rank.py
@@ -43,7 +43,6 @@ def solution(info, query):
 
     for i, req in enumerate(require):
         q = sum(map(lambda x: table[x], req[:-1]))
-        qualified = []
         for j, v in ap_cnt:
             if j & q == q:
                 idx = bisect_left(v, int(req[-1]))

--- a/notCoderJ/kakao/rank.py
+++ b/notCoderJ/kakao/rank.py
@@ -21,15 +21,15 @@ def solution(info, query):
     # lang job career food
     #  000  00     00   00
     table = {
-        'cpp': 64,
+        'cpp': 256,
         'java': 128,
-        'python': 256,
-        'backend': 16,
-        'frontend': 32,
-        'junior': 4,
-        'senior': 8,
-        'chicken': 1,
-        'pizza': 2,
+        'python': 64,
+        'backend': 32,
+        'frontend': 16,
+        'junior': 8,
+        'senior': 4,
+        'chicken': 2,
+        'pizza': 1,
     }
     
     ap_cnt = [[] for _ in range(512)]


### PR DESCRIPTION
### `2021 카카오 블라인드 순위 검색(lv2)`
풀이요약
bit 연산을 이용하기 위해 bit 테이블을 만들어서 이용했습니다.
1. 가능한 선택지에 대해 종류별로 1bit씩 할당해서 아래와 같이 자리값을 지정합니다.
언어는 최상위 3bit
직종은 다음 상위 2bit
경력은 그다음 상위 2bit
음식은 최하위 2bit
2. 주어진 info의 각 항목들을 해당 테이블을 이용해 값으로 치환해서 모두 더한 후
그 값을 ap_cnt의 인덱스로 하여 코딩 테스트 점수를 추가합니다.
3. 2에서 채워진 ap_cnt의 빈 값들을 모두 제거하고, (인덱스, 점수의 sorting 값) 형태로 변환합니다.
4. 주어진 query를 파싱해서 2번과 같이 table을 이용해 위치 값으로 치환한 후
해당 값과 ap_cnt의 인덱스를 and연산해서 query의 위치값과 동일한 경우
이진 탐색을 이용해 현재 query의 점수보다 큰 점수의 갯수를 구해 해당 answer자리에 더해줍니다.

어려웠던 점
처음에는 딕셔너리에다가 선택가능한 각 항목별로 info의 각 index를 리스트 형태로 넣어주고 query에서 일치하는 리스트들을 모두 가져와서 교집합을 구한 후 그 교집합의 인덱스로 점수를 만족시키는 애들을  찾아 구했습니다. 이렇게 하니 정확성은 모두 통과되는데 효율성이 0점이더라구요... 생각해보니 10만번 반복할 때 5만번씩 반복하면 터지겠다 생각했습니다.

그래서 비트연산이 떠올랐고 비트연산으로 로직을 갈아 엎었습니다. 하지만 요 방법도 속도는 많이 빨라졌지만 엣지케이스에서 위와 동일한 현상을 가져올 수 있더라구요. 그래서 한참 헤메다가 이진탐색이라는 힌트를 얻어서 통과할 수 있게 되었네요.ㅎㅎ


### `개선 사항(2021.09.12)`
희지님, 정규님 코드를 참고해서 개선 가능한 부분을 좀 더 개선해봤습니다.
개선할 부분을 살펴보자면 먼저 현재 코드에선 쿼리 시 각각을 비교하며 계산하게 되어있는데, 이렇게 되면 정규님이 말씀하신 것과 비슷하게 쿼리의 횟수(10만) * 저장해놓은 가능한 걍우 수(4 * 3 * 3 * 3 = 108) * 이진 탐색(logk, k는 각 경우에서 점수들의 갯수)라는 시간 복잡도가 나옵니다. 대략 앞에만 봐도 1080만을 넘는 연산이 필요합니다. 하지만 이부분을 희지님, 정규님처럼 모든 조합을 구해놓으면 재귀를 이용했을 때 약 2^5 - 1(31)번정도씩 5만번을 반복하면 되니 155만정도의 연산만 하면 되고 연산 횟수를 약 7배이상 줄일 수 있습니다. 그래서 이걸 적용해봤고 기존보다 효율성 테스트에서 약 8배정도 빨라진 것을 확인했습니다.
효율성을 제외한 일반 테스트에서는 다소 느려진 것을 확인했는데요. 기존 코드가 일반 테스트에서 평균 2자리 이하 속도가 나왔다면 개선된 코드는 70ms정도 범위도 나오더라구요. 이부분은 크기가 작은 케이스에 대해서도 정해진 모든 경우를 구해야 하기 때문이라고 생각합니다.

먼저, 주어진 정보를 초기에 점수를 기준으로 정렬합니다. 정렬 시 O(NlogN)이라는 것을 고려하면 쪼갠 후 작아진 크기에 대해 각각 정렬하는 것보다 초기 상태의 크기에서 정렬을 해놓는 것이 더 효율적일 것이라 생각했습니다.

그 다음 각 정보에 대한 모든 조합을 구하는 재귀 함수를 만들어 모든 경우별로 점수를 저장했습니다. 이후에는 기존 비교 방식과 달리 저장된 값을 바로 가져와서 각 크기를 계산했습니다.(아마 재귀를 쓰지않고 combinations를 이용했다면 더 빨라질 것 같다고 생각은 했으나, 조합 구현을 연습할겸 정규님처럼 직접 재귀로 구현해봤습니다.)
