### PR TITLE
[2021.09.10] 박지윤 프로그래머스 검색순위(에러케이스)

### DIFF
--- a/JYP/kakao_blind/2021_rank_search_error_1.py
+++ b/JYP/kakao_blind/2021_rank_search_error_1.py
@@ -1,0 +1,32 @@
+# error case 1
+from collections import defaultdict
+
+def solution(info, query):
+
+    criteria = []
+    requirements = []
+
+    # query 
+    for q in query:
+        q_list = q.replace('and', ' ').replace('-', '').split()
+        criteria.append(int(q_list[-1]))
+        requirements.append(q_list[:-1])
+
+
+    answer = []
+
+
+    # info search
+    for idx, base_score in enumerate(criteria):
+        sum = 0
+        for val in info:
+            applicant = val.split(' ')
+            score = int(applicant[-1])
+            if score >= base_score and len(set(requirements[idx]) - set(applicant[:-1])) == 0:
+                sum += 1
+        
+        answer.append(sum)
+
+
+
+    return answer

--- a/JYP/kakao_blind/2021_rank_search_error_2.py
+++ b/JYP/kakao_blind/2021_rank_search_error_2.py
@@ -1,0 +1,19 @@
+def solution(info, query):
+
+    requirements = []
+
+    # query 
+    answer = []
+    for q in query:
+        q_list = q.replace('and', ' ').replace('-', '').split()
+        base_score = int(q_list[-1])
+        requirements = q_list[:-1]
+        sum = 0
+        for val in info:
+            applicant = val.split(' ')
+            score = int(applicant[-1])
+            if score >= base_score and len(set(requirements) - set(applicant[:-1])) == 0:
+                sum += 1
+        answer.append(sum)
+
+	return answer

--- a/JYP/kakao_blind/2021_rank_search_error_3.py
+++ b/JYP/kakao_blind/2021_rank_search_error_3.py
@@ -1,0 +1,43 @@
+from collections import deque
+
+def solution(info, query):
+
+    # query preprocessing
+    requirements = []
+    for q in query:
+        q_list = deque(q.split())
+        base_score = 0
+        while q_list:
+            if q_list[0] == "and" or q_list[0] == "-":
+                q_list.popleft()
+
+            # score is the last element    
+            elif q_list[0].isnumeric():
+                base_score = int(q_list.popleft())
+                break
+            else:
+                q_list.rotate(-1)
+                
+        requirements.append([set(q_list), base_score])
+
+        
+    
+    # info preprocessing
+    applicants = []
+    for person in info:
+        person_info = person.split()
+        score = int(person_info[-1])
+        applicants.append([set(person_info[:-1]), score])
+        
+        
+    # filtering
+    answer = []
+    for r in requirements:
+        sum = 0
+        for applicant in applicants:
+            if applicant[1] >= r[1] and len(r[0] - applicant[0]) == 0:
+                sum += 1
+        answer.append(sum)
+
+
+    return answer

--- a/JYP/kakao_blind/2021_rank_search_error_4.py
+++ b/JYP/kakao_blind/2021_rank_search_error_4.py
@@ -1,0 +1,51 @@
+from collections import deque
+
+def solution(info, query):
+
+    # query preprocessing
+    requirements = []
+    for q in query:
+        deq = deque(q)
+        q_list = set()
+        base_score = ""
+        word = ""
+        while deq:
+            if deq[0].isalpha():
+                word += deq[0]
+                deq.popleft()
+            elif deq[0] == " ":
+                if word == "and":
+                    word = ""
+                elif word != "":
+                    q_list.add(word)
+                    word = ""
+                deq.popleft()
+            elif deq[0].isnumeric():
+                base_score += deq[0]
+                deq.popleft()
+            else:
+                deq.popleft()
+        
+        requirements.append([q_list, int(base_score)])
+
+         
+    
+    # info preprocessing
+    applicants = []
+    for person in info:
+        person_info = person.split()
+        score = int(person_info[-1])
+        applicants.append([set(person_info[:-1]), score])
+        
+        
+    # filtering
+    answer = []
+    for r in requirements:
+        sum = 0
+        for applicant in applicants:
+            if applicant[1] >= r[1] and len(r[0] - applicant[0]) == 0:
+                sum += 1
+        answer.append(sum)
+
+
+    return answer

--- a/JYP/kakao_blind/2021_rank_search_error_5.py
+++ b/JYP/kakao_blind/2021_rank_search_error_5.py
@@ -1,0 +1,67 @@
+from collections import deque
+
+def solution(info, query):
+
+    # query preprocessing
+    requirements = []
+    for q in query:
+        deq = deque(q)
+        q_list = set()
+        base_score = ""
+        word = ""
+        while deq:
+            if deq[0].isalpha():
+                word += deq[0]
+                deq.popleft()
+            elif deq[0] == " ":
+                if word == "and":
+                    word = ""
+                elif word != "":
+                    q_list.add(word)
+                    word = ""
+                deq.popleft()
+            elif deq[0].isnumeric():
+                base_score += deq[0]
+                deq.popleft()
+            else:
+                deq.popleft()
+        
+        requirements.append([q_list, int(base_score)])
+
+         
+    
+    # info preprocessing
+    applicants = []
+    for person in info:
+        dep = deque(person)
+        p_list = set()
+        score = ""
+        word = ""
+        while dep:
+            if dep[0].isalpha():
+                word += dep[0]
+                dep.popleft()
+            elif dep[0] == " ":
+                p_list.add(word)
+                word = ""
+                dep.popleft()
+            elif dep[0].isnumeric():
+                score += dep[0]
+                dep.popleft()
+            else:
+                dep.popleft()
+        
+        applicants.append([p_list, int(score)])
+        
+        
+    # filtering
+    answer = []
+    for r in requirements:
+        sum = 0
+        for applicant in applicants:
+            if applicant[1] >= r[1] and len(r[0] - applicant[0]) == 0:
+                sum += 1
+        answer.append(sum)
+
+
+    return answer

--- a/JYP/kakao_blind/2021_rank_search_error_6.py
+++ b/JYP/kakao_blind/2021_rank_search_error_6.py
@@ -1,0 +1,37 @@
+from collections import deque, Counter
+
+def solution(info, query):
+
+    # query preprocessing
+    requirements = []
+    for q in query:
+        que = deque(sorted(Counter(q.split())))
+        while que:
+            if que[0] == '-':
+                que.popleft()
+            elif que[0].isnumeric():
+                base_score = que[0]
+                que.popleft()
+            elif que[0] == 'and':
+                que.popleft()
+                break
+
+        requirements.append([set(que), int(base_score)])
+    
+    applicants = []
+    for p in info:
+        person = deque(sorted(Counter(p.split())))
+        score = int(person[0])
+        person.popleft()
+        applicants.append([set(person), score])
+
+    
+    answer = []
+    for r in requirements:
+        sum = 0
+        for applicant in applicants:
+            if applicant[1] >= r[1] and len(r[0] - applicant[0]) == 0:
+                sum += 1
+        answer.append(sum)
+        
+    return answer


### PR DESCRIPTION
이번엔 결국 못 풀었네요. ㅠㅠ
이진 탐색을 더 공부하고 빠른 시일 내에 다시 제대로 된 풀이를 업로드 해보겠습니다.
제대로 된 풀이를 못 올린 대신 에러케이스에 대한 분석을 올려봅니다.

- [노션 페이지 공유](https://freckle-alarm-005.notion.site/9efce2667be04c9caeccb03e73396d65) - 노션에도 우선 정리해 두었습니다.
- 시간은 최소, 최대 시간으로 표기했습니다.

### error case 1 
- `0.17ms` `335.60ms`
- 이중for문을 돌아봤습니다. 제출하기 전부터 이미 통과가 안될 줄은 알고 있었지만요.ㅎㅎ

### error case 2
- 앗 이건 시간 캡쳐를 안했네요.
- 그런데 다시 돌려보니 아예 에러가 납니다. 코드를 기록하다가 어딘가를 실수해서 날린 거 같기도 하고요. 
- 중요한 내용은 없으니 패스!

### error case 3
- `0.09ms` `79.09ms`
- 아까보다 최대 시간이 훨씬 줄어서 통과할 수 있을 거라 기대했는데 실패했네요.ㅠㅠ
- 이중 for를 피하려면, 각 자료를 최소한의 조회가 발생하게 전처리 한 다음 비교 작업을 수행해보자고 생각했습니다.
- 하지만 찾아보니 문자열에 replace를 적용하면 시간초과가 발생한다고 합니다.
- 문자열 전처리에 드는 시간도 최소화하려고 문자와 숫자 부분을 분리해서 문자 부분을 set으로 처리해서 쿼리와 지원자 데이터 스펙을 비교했습니다.
- replace 함수를 버렸더니 빨라지긴 했는데 여전히 시간초과네요. 이게 핵심이 아닌가봅니다.

### error case 4
- `0.14ms` `78.79ms`
- 혹시 split도 버리면 통과하려나 기대를 했는데, 역시 실패했습니다. 
- 4번 케이스는 쿼리문에서만 replace, split을 버리고 구현한 케이스입니다.
- 문자열 압축 내지는 가공을 최대한 반복문 한 바퀴 안에 끝내보려고 했어요.

### error case 5
- `0.23ms` `106.55ms`
- info에서도 split을 버리려고 deque를 썼는데
- 오히려 시간이 더 걸리네요. split정도는 써도 되는 거 같습니다.ㅜ(여전히 이게 핵심은 아닐테지만요)

### error case 6
- `0.16ms` `86.ms`
- deque, Counter를 활용했습니다.
- 쿼리문도 지원자 데이터도 문자 / 숫자 부분을 나누어 저장하고 문자열 부분을 set으로 처리해서 비교하는 로직은 3번과 동일합니다. 시간이 더 걸린 이유는 괜히 Counter를 썼다가 다시 소트를 걸고 deque으로 바꿔주는 등의 불필요한 연산을 했기 때문일 거 같습니다. 


## 결론
- 이진탐색을 더 공부하자!