### PR TITLE
[2021.09.14] 이정규 Programmers 입국심사, 후보키

### DIFF
--- a/JeongGod/programmers/binary_search/immigration.py
+++ b/JeongGod/programmers/binary_search/immigration.py
@@ -1,0 +1,21 @@
+def solution(n, times):
+    '''
+    최대 10억으로 잡고 mid값을 구한다.
+    mid값일 때 심사관들이 몇 명의 사람을 처리할 수 있는지 판단한다.
+    1. target < n
+        mid를 키운다.
+    2. target >= n
+        mid를 줄인다.
+    '''
+
+    left, right = 1, n*max(times)
+    while left <= right:
+        mid = (left+right) // 2
+        # mid에서 몇 명을 처리할 수 있는지
+        target = sum(mid // t for t in times)
+        if target < n:
+            left = mid + 1
+        else:
+            right = mid - 1
+    
+    return left

--- a/JeongGod/programmers/kakao/candidate_key.py
+++ b/JeongGod/programmers/kakao/candidate_key.py
@@ -1,0 +1,81 @@
+## 조합 사용
+from itertools import combinations
+
+answer = 0
+def solution(relation):
+    # 유일성 체크
+    def uni_check(idxs):
+        tmp = set()
+        for row in relation:
+            tmp.add(tuple(row[int(idx)] for idx in idxs))
+            # 길이가 같다면 유일성 만족
+        return len(tmp) == len(relation)
+    
+    # 최소성 체크
+    visited = []
+    def mini_check(idxs):
+        for v in visited:
+            # 만약 합집합을 했는데 길이가 같다면 최소성을 만족못한다.
+            # ex) v = (2,4) idxs = (2,3,4)
+            if len(idxs) == len(v | set(idxs)):
+                return False
+        visited.append(set(idxs))
+        return True
+    
+    # 전체 체크
+    def dfs(rel_idx, cnt):
+        global answer
+        # 다 둘러봤다면
+        if cnt > len(relation[0]):
+            return
+        for com in combinations(rel_idx, cnt):
+            # 해당 조합이 유일성을 만족한다면
+            # (0), (2,3), (1,3,4)
+            if uni_check(com) and mini_check(com):
+                print(com)
+                answer += 1
+        dfs(rel_idx, cnt+1)
+    
+    
+    dfs(set(range(len(relation[0]))), 1)
+    
+    return answer
+
+## Bitmask
+def solution(relation):
+    '''
+    비트마스크 => 00000000(컬럼의 개수)
+    '''
+    answer = 0
+    # bit => col의 번호로 변경
+    def bit_to_col(bit):
+        result = []
+        col = 0
+        while bit:
+            if bit%2 != 0:
+                result.append(col)
+            bit >>= 1
+            col += 1
+        return result
+    # 유일성 체크
+    def uni_check(idxs):
+        tmp = set()
+        for row in relation:
+            tmp.add(tuple(row[int(idx)] for idx in bit_to_col(idxs)))
+            # 길이가 같다면 유일성 만족
+        return len(tmp) == len(relation)
+    
+    # 최소성 체크
+    def mini_check(idxs):
+        for v in visited:
+            if v & idxs == v :
+                return False
+        return True
+    
+    visited = []
+    for i in range(1<<len(relation[0])):
+        if uni_check(i) and mini_check(i):
+            visited.append(i)
+            answer += 1
+    
+    return answer


### PR DESCRIPTION
### `Lv3 입국심사`
"이분 탐색"이라는 키워드에 꽃혀서 뭔가 바로 풀이가 떠오르긴 했네요. 실전에서는 바로 떠오를 수 있을지는 모르겠네요ㅠㅠ
마지막에 자꾸 테스트케이스 4~5개정도가 틀리길래 왜그런가 봤더니 `n * max(times)`를 안하고 10억으로 잡고해서 삽질 좀 했네요.
<풀이>
1. left : 제일 최소로 걸리는 시간, right : 최고로 많이 걸리는 시간
2. 이분 탐색을 이용해 mid(시간)일 경우에 현재 심사위원들이 몇 명을 처리할 수 있는지 판단합니다.
심사위원이 mid인 시간에 처리할 수 있는 최대 인원 = mid // 심사위원이 1명 처리하는데 걸리는 시간
3. 만약 그 인원이 현재 n명보다 많다면 mid를 작은 곳에서 탐색합니다. 반대는 mid를 큰 값에서 탐색합니다.
4. 이분탐색이 끝나면 left값을 return합니다.

### `Lv2 후보키`
처음에 조합으로 먼저 풀고, 진성님이 전에 푸셨던 비트마스크로 풀 수 있어보여서 다른 사람 풀이를 참조해서 풀어봤습니다.
아직 비트마스크가 익숙치 않아서 쓰기 힘들더라구요.. 그래도 코테에서 자주 등장하는 유형같아보이니 열심히 연습해야겠습니다.

<조합 풀이>
모든 조합을 다 둘러보는 것으로 풀이를 했습니다.
1. dfs를 이용하여 모든 조합을 다 둘러봅니다.
- 유일성 판단
   1. 해당 index끼리 튜플로 묶어 집합으로 저장하여 유일성을 확인했습니다.
- 최소성 체크
   1. 후보키들을 집합으로 저장했습니다. 
   2. 후보키와 합집합을 했을시에 길이가 그대로라면 해당 키는 후보키를 갖고 있는 것으로 판단하여 최소성을 체크합니다.

<비트마스크 풀이>
위와 로직은 똑같습니다. 모든 조합 => 비트마스크로 연산을 진행합니다.