### PR TITLE
[2021.09.14] 전진성 프로그래머스 입국심사(lv3)

### DIFF
--- a/notCoderJ/binary_search/immigration.py
+++ b/notCoderJ/binary_search/immigration.py
@@ -1,0 +1,31 @@
+'''
+  풀이 요약
+    1. 모든 사람이 검사를 마친 최대 시간을 구합니다. == 최대 심사 시간 * (입국자 / 심사자)
+    2. 이분 탐색을 수행하며 매번 처리 시간을 반토막내고, 해당 시간에 각 심사원들이 처리한 입국자 수를 구해 합하고
+      그 수와 총 입국자의 수를 비교합니다.
+      2-1. 만약 같거나 넘는다면 answer값을 현재 중앙값으로 갱신하고 중앙값의 좌측에 대해 2번 과정을 재수행합니다.
+      2-2. 만약 작다면 중앙값의 우측에 대해 2번 과정을 재수행합니다.
+'''
+
+def solution(n, times):
+    answer = 0
+    # 1. max time을 구합니다.
+    t_max = max(times) * (sum(divmod(n, len(times))))
+    
+    # 2. 이분탐색을 수행하며, 최종 처리 시간을 구합니다.
+    def bi_search(start, end):
+        nonlocal answer
+        if start > end:
+            return
+        
+        mid = (start + end) // 2
+        processed = sum(map(lambda x: mid // x, times))
+        if processed >= n:
+            answer = mid
+            bi_search(start, mid - 1)
+        else:
+            bi_search(mid + 1, end)
+    
+    bi_search(0, t_max)
+    
+    return answer

--- a/notCoderJ/kakao/candidate_key.py
+++ b/notCoderJ/kakao/candidate_key.py
@@ -1,0 +1,35 @@
+'''
+  풀이 요약
+    bitmask를 이용해서 풀었습니다.
+    bitmask 문제 풀이가 어떤 방식인지 제대로 풀어본적이 없어서 이런식으로 쓰는게 맞나 싶네요...
+    
+    1. 먼저 컬럼의 모든 조합의 수만큼 True 값으로 후보키 리스트를 초기화해줍니다.
+    2. bitmask를 1부터 최대 조합의 수까지 순회하며 현재 bitmask의 후보키 값을 확인합니다.
+    3. 만약 후보키 값이 True인 경우 relation을 하나씩 돌며 현재 bitmask 내 '1'인 부분에 해당하는 컬럼들만 뽑아서 튜플을 집합에 넣어줍니다.
+      3-1. 중복 튜플이 발생하는 경우 현재 bitmask에서의 후보키 값을 False로 변경합니다.
+      3-2. 중복 튜플이 없는 경우 현재 bitmask보다 1 큰 값부터 최대 조합의 수까지 순회하며 현재 bitmask를 포함하는 조합들에서의 후보키들을 False로 변경해줍니다.
+    4. 후보키 리스트에서 True인 값들만 카운트하여 반환합니다.
+'''
+
+def solution(relation):
+    mask_len = 2 ** len(relation[0])
+    
+    # 0000 0000
+    keys = [True for _ in range(mask_len)]
+    keys[0] = False
+    
+    for mask in range(1, mask_len):
+        if keys[mask]:
+            items = set()
+            for tp in relation:
+                item = tuple([tp[i] for i, v in enumerate(bin(mask)[2:][::-1]) if v == '1'])
+                if item in items:
+                    keys[mask] = False
+                    break
+                items.add(item)
+            else:
+                for i in range(mask + 1, mask_len):
+                    if mask & i == mask:
+                        keys[i] = False
+
+    return keys.count(True)


### PR DESCRIPTION
### `입국심사`
이 문제는 그림을 그려놓고 생각해보니 방향성을 좀 더 쉽게 잡을 수 있어서 어렵지 않게 풀었습니다.

 풀이 요약
    1. 모든 사람이 검사를 마친 최대 시간을 구합니다. == 최대 심사 시간 * (입국자 / 심사자)
    2. 이분 탐색을 수행하며 매번 처리 시간을 반토막내고, 해당 시간에 각 심사원들이 처리한 입국자 수를 구해 합하고
      그 수와 총 입국자의 수를 비교합니다.
      2-1. 만약 같거나 넘는다면 answer값을 현재 중앙값으로 갱신하고 중앙값의 좌측에 대해 2번 과정을 재수행합니다.
      2-2. 만약 작다면 중앙값의 우측에 대해 2번 과정을 재수행합니다.

### `후보키`
어려웠던 점
처음에는 간단하게 생각하고 combinations를 이용해서 컬럼의 인덱스에 대한 모든 조합을 구한 후 후보키가 발생하는지 확인하였습니다. 만약 후보키가 발생하면 그 후보키를 만든 인덱스를 제거해주면서 다음 컬럼의 인덱스 조합을 구할 때 해당 인덱스가 포함되지 않게 하였습니다. 이렇게 했더니 테스트 케이스에서 5개정도? 계속 실패하더라구요. 도통 원인을 못찾겠어서 질문 게시판을 좀 찾아보니 최소성과 관련된 부분이라는 글을 보고 곰곰히 생각해봤습니다. 생각하다 보니 이렇게하면 제외한 키로 만들 수 있는 조합을 배제해버리게 된다는 걸 꺠달았습니다. 그래서 어떻게 할까 고민을 하다가 잠깐 생각해봤던 비트마스크를 이용해보기로 마음먹고 코드를 갈아엎으니 통과할 수 있었습니다.

풀이 요약
bitmask를 이용해서 풀었습니다.
bitmask 문제 풀이가 어떤 방식인지 제대로 풀어본적이 없어서 이런식으로 쓰는게 맞나 싶네요...
    
1. 먼저 컬럼의 모든 조합의 수만큼 True 값으로 후보키 리스트를 초기화해줍니다.
2. bitmask를 1부터 최대 조합의 수까지 순회하며 현재 bitmask의 후보키 값을 확인합니다.
3. 만약 후보키 값이 True인 경우 relation을 하나씩 돌며 현재 bitmask 내 '1'인 부분에 해당하는 컬럼들만 뽑아서 튜플을 집합에 넣어줍니다.
3-1. 중복 튜플이 발생하는 경우 현재 bitmask에서의 후보키 값을 False로 변경합니다.
3-2. 중복 튜플이 없는 경우 현재 bitmask보다 1 큰 값부터 최대 조합의 수까지 순회하며 현재 bitmask를 포함하는 조합들에서의 후보키들을 False로 변경해줍니다.
4. 후보키 리스트에서 True인 값들만 카운트하여 반환합니다.