### PR TITLE
[2021.09.14] 박지윤 프로그래머스 - 입국심사, 카카오 - 후보키

### DIFF
--- a/JYP/Programmers_test_kit/enter.py
+++ b/JYP/Programmers_test_kit/enter.py
@@ -1,0 +1,20 @@
+def solution(n, times):
+    times.sort()
+    start = 1
+    end = times[-1] * n # maximum
+
+    while start < end:
+        mid = (start + end) // 2
+        cnt = 0
+
+        for time in times:
+            cnt += mid // time
+
+        if cnt < n:
+            start = mid + 1
+        else:
+            end = mid
+
+        answer = start
+    
+    return answer

--- a/JYP/kakao_blind/2019_key.py
+++ b/JYP/kakao_blind/2019_key.py
@@ -1,0 +1,52 @@
+#relation = [["100","ryan","music","2"],["200","apeach","math","2"],["300","tube","computer","3"],["400","con","computer","4"],["500","muzi","music","3"],["600","apeach","music","2"]]
+
+from itertools import combinations
+def solution(relation):
+    row = len(relation) # 행
+    col = len(relation[0]) # 열
+    cols = [i for i in range(col)]
+
+    # 선택할 컬럼의 조합의 경우의 수 구하기
+    # 예 : (0), (1), (2), (3), (0, 1), (0, 2), ... , (0, 1, 2, 3)
+    # combination배열의 차원을 늘리지 않기 위해 extend로 추가
+    combination = []
+    for i in range(1, col+1):
+        combination.extend((combinations(cols, i)))  
+    
+
+    # 유일성 체크
+
+    # 다중 for문
+    # col * row <= 160이므로, 
+    # for를 조금 과도하게 돌아도 시간복잡도, 메모리 이슈는 없을 것 같아서 그냥 했습니다.
+    unique = []
+    for combi in combination:
+            # 이 부분을 리스트 컴프리헨션으로 작성하지 않으면 배열의 차원이 증가해서 이렇게 두었습니다.(*확인필요)
+            # 조합 패턴에 맞게 데이터를 다시 튜플로 모아줍니다.
+                # 예를 들어 combi = (0, 1)인 경우, 
+                # temp = [('100', 'ryan'), ('200', 'apeach'), ... , ('600', 'apeach')] 
+                # 원래 데이터의 0행과 1행을 선택한 조합이 됩니다.
+            temp = [tuple([data[c] for c in combi]) for data in relation]
+            
+            # temp를 집합으로 만들었을 때 전체 행의 수와 같으면 유일성을 만족한다고 판단합니다.
+            if len(set(temp)) == row:
+                unique.append(combi)
+
+    
+    # 최소성 체크
+    # result에는 유일성을 만족하는 조합방법(레시피?!)을 담은 튜플이 있음(정렬은 안 된 상태)
+    # 예 : {(0, 1), (1, 2), (0, 1, 2), ... (0, 1, 2, 3), (0)}
+        # 여기서 (0, 1)과 (0, 1, 2), (0, 1, 2, 3)은 모두 (0, 1)을 포함하므로 뒤의 2개 튜플은 리스트에서 삭제하기
+        # 삭제할 때 remove를 쓰면 없는 요소를 지우려고 할 때 에러가 생기니 discard 권장
+        # 리스트 요소 삭제는 시간복잡도 이슈로 바람직하지 않다고 알고 있으나 테스트케이스 기준 result의 데이터 개수가 10개여서 별 무리 없을 것이라 판단함
+    result = set(unique)
+    for i in range(len(unique)):
+        for j in range(i+1, len(unique)): 
+            if len(unique[i]) == len(set(unique[i]) & set(unique[j])):
+                result.discard(unique[j])
+        
+
+    return len(result)
+
+
+#print(solution(relation))


### PR DESCRIPTION
- 후보키는 마지막에 최소성에서 계속 걸리고 있어서 내일 좀 더 연구한 다음에 올려보겠습니다 🙏
- 아직 머지가 안됐네요, 업데이트 했습니다!

### 입국심사
- bisect를 한 번 써보려고 했는데 결국 못쓰고 일반적인(?) while문으로 해결했습니다.
- 인터넷도 많이 참고했고요; 

`로직`
- 어떤 값을 탐색할 것인가? 여기서 좀 헤맸어요. 사람 수? 입력값 times그 자체? 
    - 답은 최소시간부터 최대시간, 시간 그 자체를 두고 탐색해야 하는 거였더라구요.;
    - 이진 탐색시 탐색 대상을 잘 찾아야겠어요.
- 검색대에서 각각 time만큼의 시간을 쓴다면 한 검색대마다 사용할 수 있는 시간(mid)동안 mid//time 만큼의 인원을 처리할 수 있습니다.
- 그 mid//time값의 합을 모두 모으면 전체 검색대에서 사용할 수 있는 시간 동안 처리할 수 있는 인원의 총합이 됩니다(cnt)
- 인원 총합이 문제에서 준 n보다 작으면 탐색구간을 오른쪽(*mid보다 긴 시간)으로 옮기고(start = mid+1)
- 인원 총합이 문제에서 준 n보다 크거나 같으면 탐색구간을 왼쪽(*mid보다 더 짧은 시간)으로 옮깁니다.
- 시작 구간이 종료 구간과 같거나 넘어갈 때 while문이 종료되고 그때의 시작시간이 최솟값이라서 이를 답으로 반환합니다.
- (마지막 줄 제가 이해가 부족한지 말로 설명하고 나니 좀 이상한데, 보시고 아니다 싶으면 댓글 부탁드립니다 🙇‍♀️)

`알게된 점`
- 이진탐색의 기본은 정렬된 값을 돈다는 것, 그리고 시간복잡도가 로그스케일로 줄어들 수 있다는 점은 이번 코드 풀어보면서 이해가 되었습니다. 


### 후보키
`로직`
- 1) 선택할 컬럼의 조합의 경우의 수 구하기
    예 : (0), (1), (2), (3), (0, 1), (0, 2), ... , (0, 1, 2, 3)
    combination배열의 차원을 늘리지 않기 위해 extend로 추가
- 2) 유일성 체크
    다중 for문
    col * row <= 160이므로, 
    for를 조금 과도하게 돌아도 시간복잡도, 메모리 이슈는 없을 것 같아서 그냥 했습니다.

    조합 패턴에 맞게 데이터를 다시 튜플로 모아줍니다.
    예를 들어 combi = (0, 1)인 경우, 
    temp = [('100', 'ryan'), ('200', 'apeach'), ... , ('600', 'apeach')] 
    원래 데이터의 0행과 1행을 선택한 조합이 됩니다.
           
    temp를 집합으로 만들었을 때 전체 행의 수와 같으면 유일성을 만족한다고 판단합니다.
          
 - 3) 최소성 체크
    result에는 유일성을 만족하는 조합방법(레시피?!)을 담은 튜플이 있음(정렬은 안 된 상태)
    예 : {(0, 1), (1, 2), (0, 1, 2), ... (0, 1, 2, 3), (0)}
        여기서 (0, 1)과 (0, 1, 2), (0, 1, 2, 3)은 모두 (0, 1)을 포함하므로 뒤의 2개 튜플은 리스트에서 삭제하기
        삭제할 때 remove를 쓰면 없는 요소를 지우려고 할 때 에러가 생기니 discard 권장
        리스트 요소 삭제는 시간복잡도 이슈로 바람직하지 않다고 알고 있으나 테스트케이스 기준 result의 데이터 개수가 10개여서 별 무리 없을 것이라 판단함