### PR TITLE
[2021.10.27] 이정규 Programmers 구명보트, 광고삽입

### DIFF
--- a/JeongGod/programmers/greedy/life_boat.py
+++ b/JeongGod/programmers/greedy/life_boat.py
@@ -1,0 +1,17 @@
+def solution(people, limit):
+    people.sort()
+    left, right = 0, len(people)-1
+    answer = 0
+
+    while left < right:
+        total = people[left] + people[right]
+        if total <= limit:
+            left += 1
+            right -= 1
+        else:
+            right -= 1
+        answer += 1
+
+    if left == right:
+        answer += 1
+    return answer

--- a/JeongGod/programmers/kakao/insert_ad.py
+++ b/JeongGod/programmers/kakao/insert_ad.py
@@ -1,0 +1,62 @@
+def solution(play_time, adv_time, logs):
+    """
+    1. 초마다 시청자 수가 몇 명이 있는지 센다.
+    2. 시청자의 수는 곧 해당 초에 광고를 삽입했을 때 보여지는 초와 같다.
+    3. 0~play_time까지 adv_time만큼 sum을 하여 그의 합이 가장 큰 값을 시작 시간으로 둔다.
+    """
+    def time_to_seconds(t):
+        h, m, s = t.split(":")
+        return int(h)*60**2 + int(m)*60 + int(s)
+
+    def seconds_to_time(t):
+        h = t // 3600
+        t %= 3600
+        m = t // 60
+        t %= 60
+        s = t
+        return f"{h:0>2}:{m:0>2}:{s:0>2}"
+
+    # 모두 초단위로 변경한다.
+    play_time = time_to_seconds(play_time)
+    adv_time = time_to_seconds(adv_time)
+    viewer = [0] * (play_time+2)
+
+    for l in logs:
+        start, end = list(map(lambda x: time_to_seconds(x), l.split("-")))
+        # start에서 viewer가 추가되고, end에서는 viewer가 빠져나간다.
+        viewer[start] += 1
+        viewer[end] -= 1
+
+    # adv_time까지의 합을 구한다.
+    adv_time_sum = 0
+    cur = 0
+    for i in range(adv_time):
+        """
+        1. viewer[i] < 0
+            => 시청자가 빠져나간 것이다.
+        2. viewer[i] > 0
+            => 시청자가 추가 되었다는 뜻이다.
+        """
+        if viewer[i] > 0:
+            cur += viewer[i]
+        elif viewer[i] < 0:
+            cur = cur + viewer[i] if cur + viewer[i] >= 0 else 0
+        adv_time_sum += cur
+
+    max_time = adv_time_sum
+    answer = 0
+    """
+    구간합을 사용한다.
+    1. 처음 합을 구한다. (위에 adv_time_sum)
+    2. 한 칸씩 전진하면서 adv_time_sum에서 왼쪽 값은 빼주고, 오른쪽 값은 더해준다.
+    3. 그러면 O(n)으로 구간합을 구할 수 있다.
+    """
+    for left in range(play_time-adv_time):
+        right = left + adv_time
+        # left, right에서 추가된 viewer가 있는지 검사한다.
+        cur += viewer[right] - viewer[left]
+        adv_time_sum += cur
+        if adv_time_sum > max_time:
+            max_time = adv_time_sum
+            answer = left + 1
+    return seconds_to_time(answer)


### PR DESCRIPTION
### `Lv2. 구명보트`
가장 최적으로 보트를 타는 일은, 보트타는 사람이 limit에 맞춰 타는 것입니다.
그렇기에 투포인터를 이용하여 limit의 크기에 맞춰 탈 수 있게끔 하였습니다.
<풀이>
1. 먼저 사람을 무게순으로 정렬합니다.
2. 투포인터를 이용합니다. left(가장 가벼운 사람)과 right(가장 무거운 사람)의 사람을 한 명씩 지목합니다.
3. 그의 합이 limit보다 크다면, right(가장 무거운 사람)은 혼자 탈 수 밖에 없습니다. 그래서 오른쪽 사람만 따로 보트에 태웁니다.
4. 작다면, left와 right의 사람을 보트에 태웁니다.

### `Lv3. 광고삽입`
어렵네유ㅠㅠ 카카오는 시간문제가 많이 나오는 것 같은데 제일 껄끄럽네요ㅠㅠ
풀이가 생각이 안나서 구글링을 통해 풀이방법만 카피했슴다..ㅎㅎㅎ
<전체적인 풀이>
1. 광고 시간들을 초단위로 변경한 뒤, 각 초마다 시청자의 수를 센다.
2. adv_time만큼 play_time을 돌면서, 각 시청자의 수를 합한다. => 이게 곧 시청자들이 adv_time을 보는 시간
3. 시청자들이 가장 많이 보는 시간대를 선택한다.

<세부적인 풀이>
1. logs의 데이터마다 초단위로 "시작", "끝"으로 변형해서 for문을 돌려 시청자의 수를 업데이트한다면 O(n^2)로 시간초과가 나옵니다.
그래서 "시작"에 +1, "끝" -1 을 하여 진행합니다.
2. 이제 0~adv_time까지의 광고 노출시간을 구합니다. viewer[i]가 양수면 시청자가 들어온 것이고, viewer[i]가 음수면 시청자가 나간 것입니다. 
3. 여기서 `adv_time`으로 항상 구간의 길이가 똑같으니 구간합을 사용합니다. 구간합을 사용하지 않으면 O(n^2)이 나와 시간초과가 나옵니다.
`0~adv_time`까지의 합을 구했다면 여기서 한 칸씩 이동하며 `1~adv_time+1`까지의 합을 구하는 방법은 `0~adv_time` + `adv_time+1` - `0` 입니다. 그렇게 진행하면 O(n)으로 합을 비교할 수 있습니다.
4. 마지막에 `answer = left + 1`은 `0~adv_time` + `adv_time+1` - `0` 에서 `0`에 해당하는 값입니다. 그렇기 때문에 +1 을 합니다.