### PR TITLE
[2021.10.21] 전진성 프로그래머스 구명보트

### DIFF
--- a/notCoderJ/greedy/life_boat.py
+++ b/notCoderJ/greedy/life_boat.py
@@ -1,0 +1,22 @@
+'''
+  풀이요약
+    보트에는 최대 2명씩만 태울 수 있기 때문에 사람들의 몸무게를 정렬하여
+    현재 남은 사람들 중 가장 무거운 사람과 가장 가벼운 사람을 계속 짝지으며 보트에 태우는 방법으로 풀이했습니다.
+'''
+
+from collections import deque
+
+def solution(people, limit):
+    answer = 0
+    dq = deque(sorted(people))
+    
+    while dq:
+        if len(dq) > 1 and dq[0] + dq[-1] <= limit:
+            dq.popleft()
+            dq.pop()
+            answer += 1
+        else:
+            dq.pop()
+            answer +=1
+    
+    return answer


### PR DESCRIPTION
### `구명보트`
풀이요약
    보트에는 최대 2명씩만 태울 수 있기 때문에 사람들의 몸무게를 정렬하여
    현재 남은 사람들 중 가장 무거운 사람과 가장 가벼운 사람을 계속 짝지으며 보트에 태우는 방법으로 풀이했습니다.

### `카카오 블라인드 광고삽입`
테스트 문제는 통과했는데, 제출 시 실패해서 못 올렸습니다. 지금 생각할 여를이 없어서... 사건이 좀 해결되는대로 다시 풀어보겠습니다.
