### PR TITLE
[2021.11.03] 박지윤 - 프로그래머스: 조이스틱 카카오:자물쇠와 열쇠

### DIFF
--- a/JYP/Programmers_test_kit/joystick.py
+++ b/JYP/Programmers_test_kit/joystick.py
@@ -1,0 +1,52 @@
+from string import ascii_uppercase
+
+'''
+풀이
+1. 알파벳 값에 대응하는 사전을 만듭니다.
+{'A': 0, 'B': 1, 'C': 2, 'D': 3, 'E': 4, 'F': 5, 'G': 6, 'H': 7, 'I': 8, 'J': 9, 'K': 10, 'L': 11, 'M': 12, 'N': 13, 'O': 12, 'P': 11, 'Q': 10, 'R': 9, 'S': 8, 'T': 7, 'U': 6, 'V': 5, 'W': 4, 'X': 3, 'Y': 2, 'Z': 1}
+2. 이름 오른쪽에 A가 있다면 왼쪽으로 이동하고, 없다면 오른쪽으로 이동하며 탐색합니다.
+
+** 현재 코드는 테스트 케이스 10, 11에서 오류가 발생합니다. 
+name = "ZZZAAAZ" 는 방향을 도중에 한 번 바꾸면 9기 나와야 하는데 저는 방향을 바꾸는 것을 고려하지 않았으므로 10을 리턴하고 있습니다.
+'''
+# 알파벳 : 숫자 값 사전 만들기
+def make_dict():
+    alpha_dict = dict()
+    for idx, alpha in enumerate(list(ascii_uppercase)):
+        if idx <= 13:
+            alpha_dict[alpha] = idx
+        else:
+            alpha_dict[alpha] = 26 - idx
+    
+    return alpha_dict
+
+
+def solution(name):
+    answer = 0
+
+    if set(list(name)) == {"A"}:
+        return 0
+
+    alpha_dict = make_dict()
+
+    right_answer = 0
+    left_answer = 0
+
+    for idx, n in enumerate(name):
+        if idx!= 0:
+            right_answer += 1
+        if n != "A":
+            right_answer += alpha_dict[n]
+   
+    for i in range(0, -(len(name)), -1):
+        if name[i] != "A":
+            plus = alpha_dict[name[i]] + 1 if i != 0 else alpha_dict[name[i]]
+            left_answer += plus
+        else:
+            plus = 1 if i != -(len(name)-1) else 0
+            left_answer += plus
+    
+    
+    answer = min(left_answer, right_answer)
+    
+    return answer

--- a/JYP/Programmers_test_kit/target_number.py
+++ b/JYP/Programmers_test_kit/target_number.py
@@ -1,0 +1,101 @@
+'''
+풀이 1 - 이진 탐색 트리는 아니지만 계산 결과를 층으로 나누어 누적합 계산하기
+- 질문 게시판 참고했습니다;
+- 현재 레이어(배열)에 존재하는 값에 다음에 오는 숫자를 더하고 빼서 추가
+- 예 : numbers = [1, 2, 3] 
+                    1
+            1+2         1-2 
+    1+2+3   1+2-3       1-2+3   1-2-3
+- 다음 레이어에 있는 원소 개수는 이전 레이어의 원소 개수보다 2배씩 증가함
+- 최종 레이어에 존재하는 값에서 원하는 target이 있는지 여부를 카운트하기
+
+'''
+
+def solution(numbers, target):
+
+    answer = 0
+    curr_layer = []
+
+    for idx in range(len(numbers)):
+        
+        next_layer = []
+        next_num = numbers[idx]
+        if idx == 0:
+            curr_layer.append(numbers[idx])
+            curr_layer.append(-numbers[idx])
+        else:
+            for curr_num in curr_layer:
+                next_layer.append(curr_num + next_num)
+                next_layer.append(curr_num - next_num)
+
+            curr_layer = next_layer
+    
+    answer = curr_layer.count(target)
+
+    return answer
+
+'''
+풀이 2 - 이진트리 생성 후 dfs 수행(실패)
+...결과를 보니 뭔가 이상함
+'''
+
+'''
+class Node:
+    def __init__(self, data):
+        self.data = data
+        self.left = None
+        self.right = None
+
+class BinaryTree():
+    def __init__(self, root):
+        self.root = root
+    
+    def insert(self, val):
+        self.root = self._insert_val(self.root, val)
+        return self.root is not None
+
+    def _insert_val(self, node, data):
+        if node is None:
+            node = Node(data)
+        else:
+            node.left = self._insert_val(node.left, data)
+            node.right = self._insert_val(node.right, (-1)*data)
+        
+        return node
+
+    
+    global nums
+    nums = []
+    
+    def preorder(self, n):
+        if n != None:        
+            nums.append(n.data)
+            if n.left:
+                self.preorder(n.left)
+            if n.right:
+                self.preorder(n.right)
+
+
+
+
+def solution(numbers, target):
+    
+    tree=BinaryTree(Node(0))
+
+    for num in numbers:
+        tree.insert(num)
+    
+    tree.preorder(tree.root)
+
+    len_n = len(numbers)
+    answer = 0
+
+    for i in range(1, len(nums) - len_n, len_n):
+        print(nums[i:i+len_n])
+        if sum(nums[i:i+len_n]) == target:
+            answer += 1
+    
+    print(len(nums))
+    return answer
+
+'''

--- a/JYP/kakao_blind/2018_news_clustering.py
+++ b/JYP/kakao_blind/2018_news_clustering.py
@@ -1,0 +1,78 @@
+import math
+import re
+from collections import deque
+
+'''
+풀이
+1. 전처리
+- 알파벳 소문자만 남기고 모두 공백으로 치환합니다.
+- 연속된 글자 2개를 가져와서 둘 다 알파벳이라면 리스트에 추가합니다. 
+- 리스트에 추가할 때 중복 여부를 확인하지 않으면 자동으로 다중집합이 생성됩니다.
+
+2. 다중집합 합집합 만들기
+- b 집합의 원소가 a 집합에 없다면 결과에 추가해주고
+- b 집합의 원소가 a 집합이 있다면 결과에 추가하지 않으며 a 집합에서도 제거합니다. 
+- 이때 copy 메서드를 사용하지 않으면 결과에 오류가 발생합니다. (참조만 하는 것이 아니라 실제 값을 복사해야 함 - 얕은복사 가능)
+
+3. 다중집합 교집합 만들기
+- b 집합의 원소가 a 집합에 있다면 결과 리스트에 추가합니다. 
+
+4. 결과
+- 문제의 지시대로 교/합 나눗셈 결과에 65536을 곱하고 소수점 이하 버림을 하여 정수 결과를 반환합니다.
+'''
+
+def preprocessing(str):
+    new_str = re.sub(r'[^a-z]',' ',str.lower())
+    new_str = re.sub(r'[0-9]',' ',new_str)
+
+    result = []
+    for i in range(len(new_str)-1):
+        elem = ''.join(new_str[i:i+2])
+        if elem.isalpha():
+            result.append(elem)
+
+    return result
+
+# multiset union 다중집합 합집합
+def make_union(a, b):
+    a_temp = deque(a.copy())
+    a_result = a.copy()
+
+    for b_elem in b:
+        if b_elem not in a_temp:
+            a_result.append(b_elem)
+        else:
+            del a_temp[a_temp.index(b_elem)]
+
+    return a_result
+
+
+# multiset intersection 다중집합 교집합
+def make_intersection(a, b):
+    a = deque(a)
+    result = []
+    for b_elem in b:
+        if b_elem in a:
+            del a[a.index(b_elem)]
+            result.append(b_elem)
+    
+    return result
+
+
+def solution(str1, str2):
+    answer = 0
+    
+    str1 = preprocessing(str1)
+    str2 = preprocessing(str2)
+
+    len_union = len(make_union(str1, str2))
+    len_inter = len(make_intersection(str1, str2))
+    
+    if len_union == 0:
+        result = 1
+    else:
+        result = len_inter / len_union
+    
+    answer = math.trunc(result * 65536)
+
+    return answer

--- a/JYP/kakao_blind/2020_lock_key.py
+++ b/JYP/kakao_blind/2020_lock_key.py
@@ -1,0 +1,68 @@
+'''
+풀이
+1. lock은 padding을 주어서 판의 크기를 늘립니다.(패딩값은 전방향 2*(열쇠 매트릭스 -1)씩 추가)
+2. 열쇠는 0, 90, 180, 270도 회전하여 준비합니다.
+3. 4종류의 열쇠를 가지고 padding이 추가된 lock 판에서 처음부터 끝까지 완전탐색합니다.(0이상 N+M-1미만)
+4. 탐색 시 padding 부분에서는 비교된 값을 무시하며 기존의 lock부분에서는 비교 연산 값이 유효해야 하므로 XOR 연산을 사용합니다.
+'''
+
+def rotate(matrix):
+    M = len(matrix[0]) 
+    result = [ [0] * M for _ in range(M)]
+
+    for r in range(M):
+        for c in range(M):
+            result[c][M-1-r] = matrix[r][c]
+
+    return result
+
+
+def make_padding(N, M, lock):
+    padding = [[0] * ((N-1) + 2*(M-1))]
+    
+    # 상단부 패딩 추가
+    for _ in range(M-1):
+        lock = padding + lock
+    
+    # lock이 있는 부분에서 좌우 패딩 추가
+    for r in range(M-1, N+M-1):
+        lock[r] = [0] * (M-1) + lock[r] + [0] * (M-1)
+    
+    # 하단부 패딩 추가
+    for _ in range(N+M-1):
+        lock += padding
+
+    return lock
+
+# 완전탐색
+def search(key, lock):
+    N = len(lock[0]) 
+    M = len(key[0]) 
+
+    lock = make_padding(N, M, lock)
+
+    for r in range(N+M-1):
+        for c in range(N+M-1):
+            for i in range(M):
+                for j in range(M):
+                    # padding 이전의 lock 범위 안에서 자물쇠와 열쇠가 서로 맞는지 XOR 연산 수행
+                    if M-1 <= r+i <= N+M-2 and M-1 <= c+j <= N+M-2 and key[i][j] ^ lock[r+i][c+j] == 0:
+                        return False
+
+        return True
+
+def solution(key, lock):
+
+    rotate_90 = rotate(key)
+    rotate_180 = rotate(rotate_90)
+    rotate_270 = rotate(rotate_180)
+
+    answer = False
+    keys = [key, rotate_90, rotate_180, rotate_270]
+
+    for k in keys:
+        if search(k, lock) == True:
+            answer = True
+    # answer = search(key, lock) | search(rotate_90, lock) | search(rotate_180, lock) | search(rotate_270, lock)
+
+    return answer


### PR DESCRIPTION
## 자물쇠와 열쇠(실패)
'''
1. lock은 padding을 주어서 판의 크기를 늘립니다.(패딩값은 전방향 2*(열쇠 매트릭스 -1)씩 추가)
2. 열쇠는 0, 90, 180, 270도 회전하여 준비합니다.
3. 4종류의 열쇠를 가지고 padding이 추가된 lock 판에서 처음부터 끝까지 완전탐색합니다.(0이상 N+M-1미만)
4. 탐색 시 padding 부분에서는 비교된 값을 무시하며 기존의 lock부분에서는 비교 연산 값이 유효해야 하므로 XOR 연산을 사용합니다.

## 조이스틱(실패)
1. 알파벳 값에 대응하는 사전을 만듭니다.
2. 이름 오른쪽에 A가 있다면 왼쪽으로 이동하고, 없다면 오른쪽으로 이동하며 탐색합니다.

- 현재 코드는 테스트 케이스 10, 11에서 오류가 발생합니다. 
name = "ZZZAAAZ" 는 방향을 도중에 한 번 바꾸면 9가 나와야 하는데 저는 방향을 바꾸는 것을 고려하지 않았으므로 10을 리턴하고 있습니다.

## 타겟 넘버
- 풀이2는 망한 풀이인데, 이진 트리를 '생성'하는 것부터 막혀서... 클래스 사용하는 법 공부를 더 해야겠습니다;🙏
- 그래서 그냥 레이어를 이용해서 배열로 계산을 했습니다.
- 풀이 1 - 이진 탐색 트리는 아니지만 계산 결과를 층으로 나누어 누적합 계산하기
질문 게시판 참고했습니다;
현재 레이어(배열)에 존재하는 값에 다음에 오는 숫자를 더하고 빼서 추가
예 : numbers = [1, 2, 3] 
                    1
            1+2         1-2 
    1+2+3   1+2-3       1-2+3   1-2-3
다음 레이어에 있는 원소 개수는 이전 레이어의 원소 개수보다 2배씩 증가함
최종 레이어에 존재하는 값에서 원하는 target이 있는지 여부를 카운트하기

## 뉴스 클러스터링
1. 전처리
알파벳 소문자만 남기고 모두 공백으로 치환합니다.
연속된 글자 2개를 가져와서 둘 다 알파벳이라면 리스트에 추가합니다. 
리스트에 추가할 때 중복 여부를 확인하지 않으면 자동으로 다중집합이 생성됩니다.

2. 다중집합 합집합 만들기
b 집합의 원소가 a 집합에 없다면 결과에 추가해주고
b 집합의 원소가 a 집합이 있다면 결과에 추가하지 않으며 a 집합에서도 제거합니다. 
이때 copy 메서드를 사용하지 않으면 결과에 오류가 발생합니다. (참조만 하는 것이 아니라 실제 값을 복사해야 함 - 얕은복사 가능)

3. 다중집합 교집합 만들기
b 집합의 원소가 a 집합에 있다면 결과 리스트에 추가합니다. 

4. 결과
문제의 지시대로 교/합 나눗셈 결과에 65536을 곱하고 소수점 이하 버림을 하여 정수 결과를 반환합니다.